### PR TITLE
Added GetModified and SetUnmodified functions to XmUGrid.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(xmsgrid_py
   xmsgrid/python/xmsgrid_py.cpp
   #UGrid
   xmsgrid/python/ugrid/ugrid_py.cpp
+  xmsgrid/python/ugrid/XmEdge_py.cpp
   xmsgrid/python/ugrid/XmUGrid_py.cpp
   xmsgrid/python/ugrid/XmUGridUtils_py.cpp
 )

--- a/generateDocumentationAndDeploy.sh
+++ b/generateDocumentationAndDeploy.sh
@@ -70,7 +70,9 @@ echo "" > .nojekyll
 
 #install doxygen
 sudo apt-get update
-sudo apt-get install -y doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
+wget http://utils.aquaveo.com/doxygen-1.8.14-aquaveo.deb
+sudo apt-get install libedit2 libllvm5.0 libclang1-5.0 libxapian30
+sudo dpkg -i doxygen-1.8.14-aquaveo.deb
 
 ################################################################################
 ##### Generate the Doxygen code documentation and log the output.          #####

--- a/xmsgrid/python/ugrid/XmEdge_py.cpp
+++ b/xmsgrid/python/ugrid/XmEdge_py.cpp
@@ -1,0 +1,63 @@
+//------------------------------------------------------------------------------
+/// \file
+/// \brief
+/// \copyright (C) Copyright Aquaveo 2018. Distributed under the xmsng
+///  Software License, Version 1.0. (See accompanying file
+///  LICENSE_1_0.txt or copy at http://www.aquaveo.com/xmsng/LICENSE_1_0.txt)
+//------------------------------------------------------------------------------
+
+//----- Included files ---------------------------------------------------------
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <boost/shared_ptr.hpp>
+#include <xmscore/python/misc/PyUtils.h>
+#include <xmsgrid/ugrid/XmEdge.h>
+
+//----- Namespace declaration --------------------------------------------------
+namespace py = pybind11;
+
+namespace {
+
+//------------------------------------------------------------------------------
+/// \brief Create XmEdge from py::iterable
+/// \param[in] a_intpair py::iterable object that represents an XmEdge
+/// \return The edge.
+//------------------------------------------------------------------------------
+xms::XmEdge XmEdgeFromPyIter(const py::iterable& a_intpair)
+{
+  py::tuple pr = a_intpair.cast<py::tuple>();
+  if (py::len(pr) != 2) {
+    throw py::type_error("arg must be an 2-tuple");
+  }
+  else {
+    xms::XmEdge edge(pr[0].cast<int>(), pr[1].cast<int>());
+    return edge;
+  }
+} // XmEdgeFromPyIter
+
+}
+
+//----- Python Interface -------------------------------------------------------
+
+void initXmEdge(py::module &m)
+{
+  py::module modXmEdge = m.def_submodule("XmEdge");
+  // ---------------------------------------------------------------------------
+  // function: edges_equivalent
+  // --------------------------------------------------------------------------- 
+  const char* edges_equivalent_doc = R"pydoc(
+    Test if two edges are the same ignoring direction
+
+    Args: 
+        a_edge1 (iterable): The first edge to compare against
+        a_edge2 (iterable): The second edge to compare against
+
+    Returns:
+        bool: If two edges are same when indexes are in sorted order
+  )pydoc";
+  modXmEdge.def("edges_equivalent", [](py::iterable a_edge1, py::iterable a_edge2) -> bool {
+    xms::XmEdge edge1 = XmEdgeFromPyIter(a_edge1);
+    xms::XmEdge edge2 = XmEdgeFromPyIter(a_edge2);
+    return XmEdgesEquivalent(edge1, edge2);
+  }, edges_equivalent_doc, py::arg("a_edge1"), py::arg("a_edge2"));
+}

--- a/xmsgrid/python/ugrid/XmEdge_pyt.py
+++ b/xmsgrid/python/ugrid/XmEdge_pyt.py
@@ -1,0 +1,15 @@
+"""Test XmUGrid_py.cpp"""
+import unittest
+import xmsgrid_py
+from xmsgrid_py.ugrid import XmEdge
+
+
+class TestXmEdgeFunctions(unittest.TestCase):
+    """XmEdge Function tests"""
+
+    def test_edges_equivalent(self):
+        edge1 = (0, 1)
+        edge1a = (1, 0)
+        edge2 = (1, 2)
+        self.assertTrue(XmEdge.edges_equivalent(edge1, edge1a))
+        self.assertFalse(XmEdge.edges_equivalent(edge1, edge2))

--- a/xmsgrid/python/ugrid/XmUGrid_py.cpp
+++ b/xmsgrid/python/ugrid/XmUGrid_py.cpp
@@ -82,6 +82,26 @@ void initXmUGrid(py::module &m) {
             boost::shared_ptr<xms::VecInt> _cellstream = xms::VecIntFromPyIter(cellstream);
             return boost::shared_ptr<xms::XmUGrid>(xms::XmUGrid::New(*points, *_cellstream));
         }));
+  // Misc Functions
+  // ---------------------------------------------------------------------------
+  // function: get_modified
+  // --------------------------------------------------------------------------- 
+    const char* get_modified_doc = R"pydoc(
+        Returns the modified flag. Gets set when points or cells get changed.
+
+        Returns:
+            bool: the modified flag
+    )pydoc";
+    xmUg.def("get_modified", &xms::XmUGrid::GetModified,
+             get_modified_doc);
+    // ---------------------------------------------------------------------------
+    // function: set_unmodified
+    // --------------------------------------------------------------------------- 
+    const char* set_unmodified_doc = R"pydoc(
+        Resets the modified flag to false.
+    )pydoc";
+    xmUg.def("set_unmodified", &xms::XmUGrid::SetUnmodified,
+             set_unmodified_doc);
   // Point Functions
   // ---------------------------------------------------------------------------
   // function: get_point_count
@@ -92,7 +112,7 @@ void initXmUGrid(py::module &m) {
         Returns:
             int: the number of points
     )pydoc";
-    xmUg.def("get_point_count", &xms::XmUGrid::PointCount,
+    xmUg.def("get_point_count", &xms::XmUGrid::GetPointCount,
              point_count_doc);
   // ---------------------------------------------------------------------------
   // function: get_locations
@@ -143,9 +163,9 @@ void initXmUGrid(py::module &m) {
             point_idx (int): the index of the point to be set
             location (iterable): the location of the point
     )pydoc";
-    xmUg.def("set_location", [](xms::XmUGrid &self, int point_idx, py::iterable location) -> bool {
+    xmUg.def("set_point_location", [](xms::XmUGrid &self, int point_idx, py::iterable location) -> bool {
             xms::Pt3d loc = xms::Pt3dFromPyIter(location);
-            return self.SetLocation(point_idx, loc);
+            return self.SetPointLocation(point_idx, loc);
         }, set_location_doc,py::arg("point_idx"),py::arg("location"));
   // ---------------------------------------------------------------------------
   // function: get_point_xy0
@@ -221,6 +241,24 @@ void initXmUGrid(py::module &m) {
             boost::shared_ptr<xms::VecInt> points = xms::VecIntFromPyIter(point_idxs);
             return xms::PyIterFromVecInt(self.GetPointsAdjacentCells(*points));
         }, get_points_adjacent_cells_doc,py::arg("point_idxs"));
+
+    // ---------------------------------------------------------------------------
+    // function: is_valid_point_change
+    // ---------------------------------------------------------------------------
+      const char* is_valid_point_change_doc = R"pydoc(
+          Determine whether adjacent cells are valid after a point is moved.
+
+          Args:
+              changed_pt_idx (int): index of the point to be changed
+              new_location (iterable): location the point is to be moved to
+          Returns:
+              iterable: Whether the change is valid
+      )pydoc";
+      xmUg.def("is_valid_point_change", [](xms::XmUGrid &self, int changed_pt_idx,
+                                           py::iterable new_location) -> bool {
+        xms::Pt3d location = xms::Pt3dFromPyIter(new_location);
+        return self.IsValidPointChange(changed_pt_idx, location);
+      }, is_valid_point_change_doc, py::arg("changed_pt_idx"), py::arg("new_location"));
         // Cell Functions
   // ---------------------------------------------------------------------------
   // function: get_cell_count

--- a/xmsgrid/python/ugrid/XmUGrid_py.cpp
+++ b/xmsgrid/python/ugrid/XmUGrid_py.cpp
@@ -257,7 +257,7 @@ void initXmUGrid(py::module &m) {
       xmUg.def("is_valid_point_change", [](xms::XmUGrid &self, int point_idx,
                                            py::iterable new_location) -> bool {
         xms::Pt3d location = xms::Pt3dFromPyIter(new_location);
-        return self.IsValidPointChange(changed_pt_idx, location);
+        return self.IsValidPointChange(point_idx, location);
       }, is_valid_point_change_doc, py::arg("point_idx"), py::arg("new_location"));
         // Cell Functions
   // ---------------------------------------------------------------------------

--- a/xmsgrid/python/ugrid/XmUGrid_py.cpp
+++ b/xmsgrid/python/ugrid/XmUGrid_py.cpp
@@ -87,10 +87,10 @@ void initXmUGrid(py::module &m) {
   // function: get_modified
   // --------------------------------------------------------------------------- 
     const char* get_modified_doc = R"pydoc(
-        Returns the modified flag. Gets set when points or cells get changed.
+        Determine if the UGrid has been modified.
 
         Returns:
-            bool: the modified flag
+            bool: The modified flag.
     )pydoc";
     xmUg.def("get_modified", &xms::XmUGrid::GetModified,
              get_modified_doc);
@@ -98,7 +98,7 @@ void initXmUGrid(py::module &m) {
     // function: set_unmodified
     // --------------------------------------------------------------------------- 
     const char* set_unmodified_doc = R"pydoc(
-        Resets the modified flag to false.
+        Set the UGrid unmodified.
     )pydoc";
     xmUg.def("set_unmodified", &xms::XmUGrid::SetUnmodified,
              set_unmodified_doc);
@@ -246,19 +246,19 @@ void initXmUGrid(py::module &m) {
     // function: is_valid_point_change
     // ---------------------------------------------------------------------------
       const char* is_valid_point_change_doc = R"pydoc(
-          Determine whether adjacent cells are valid after a point is moved.
+          Determine if adjacent cells would be valid upon changing a point.
 
           Args:
-              changed_pt_idx (int): index of the point to be changed
-              new_location (iterable): location the point is to be moved to
+              point_idx (int): The index of the point.
+              new_location (iterable): The proposed new location of the point.
           Returns:
-              iterable: Whether the change is valid
+              bool: Whether the change would be valid.
       )pydoc";
-      xmUg.def("is_valid_point_change", [](xms::XmUGrid &self, int changed_pt_idx,
+      xmUg.def("is_valid_point_change", [](xms::XmUGrid &self, int point_idx,
                                            py::iterable new_location) -> bool {
         xms::Pt3d location = xms::Pt3dFromPyIter(new_location);
         return self.IsValidPointChange(changed_pt_idx, location);
-      }, is_valid_point_change_doc, py::arg("changed_pt_idx"), py::arg("new_location"));
+      }, is_valid_point_change_doc, py::arg("point_idx"), py::arg("new_location"));
         // Cell Functions
   // ---------------------------------------------------------------------------
   // function: get_cell_count

--- a/xmsgrid/python/ugrid/ugrid_py.cpp
+++ b/xmsgrid/python/ugrid/ugrid_py.cpp
@@ -16,6 +16,7 @@ namespace py = pybind11;
 //----- Python Interface -------------------------------------------------------
 
 void initUGrid(py::module &m) {
+    initXmEdge(m);
     initXmUGrid(m);
     initXmUGridUtils(m);
 }

--- a/xmsgrid/python/ugrid/ugrid_py.h
+++ b/xmsgrid/python/ugrid/ugrid_py.h
@@ -16,5 +16,6 @@ namespace py = pybind11;
 //----- Function declarations --------------------------------------------------
 void initUGrid(py::module &);
 
+void initXmEdge(py::module &);
 void initXmUGrid(py::module &);
 void initXmUGridUtils(py::module &);

--- a/xmsgrid/ugrid/XmEdge.cpp
+++ b/xmsgrid/ugrid/XmEdge.cpp
@@ -148,6 +148,16 @@ void XmEdge::SortIndexes()
   if (m_pt1 > m_pt2)
     std::swap(m_pt1, m_pt2);
 } // XmEdge::SortIndexes
+//------------------------------------------------------------------------------
+/// \brief Test if two edges are the same ignoring direction.
+/// \param a_edge1 The first edge to compare against.
+/// \param a_edge2 The second edge to compare against.
+/// \return True if two edges are same when indexes are in sorted order.
+//------------------------------------------------------------------------------
+bool XmEdgesEquivalent(const XmEdge& a_edge1, const XmEdge& a_edge2)
+{
+  return a_edge1.IsEquivalent(a_edge2);
+} // XmEdgesEquivalent
 
 } // namespace xms
 
@@ -201,6 +211,8 @@ void XmEdgeUnitTests::testIsEquivalent()
   TS_ASSERT(!(edge1 == edge1a));
   TS_ASSERT(edge1a.IsEquivalent(edge1));
   TS_ASSERT(!edge1.IsEquivalent(edge2));
+  TS_ASSERT(XmEdgesEquivalent(edge1, edge1a));
+  TS_ASSERT(!XmEdgesEquivalent(edge1, edge2));
 } // XmEdgeUnitTests::testIsEquivalent
 
 #endif

--- a/xmsgrid/ugrid/XmEdge.h
+++ b/xmsgrid/ugrid/XmEdge.h
@@ -54,5 +54,6 @@ private:
 };
 
 //----- Function prototypes ----------------------------------------------------
+bool XmEdgesEquivalent(const XmEdge& a_edge1, const XmEdge& a_edge2);
 
 } // namespace xms

--- a/xmsgrid/ugrid/XmUGrid.cpp
+++ b/xmsgrid/ugrid/XmUGrid.cpp
@@ -55,15 +55,19 @@ class XmUGridImpl : public XmUGrid
 public:
   XmUGridImpl();
 
-  // Locations
+  // Misc
+  virtual bool GetModified() const override;
+  virtual void SetUnmodified() override;
 
-  virtual int PointCount() const override;
+  // Points
+
+  virtual int GetPointCount() const override;
 
   virtual const VecPt3d& GetLocations() const override;
   virtual void SetLocations(const VecPt3d& a_locations) override;
 
   virtual Pt3d GetPointLocation(const int a_pointIdx) const override;
-  virtual bool SetLocation(const int a_pointIdx, const Pt3d& a_point) override;
+  virtual bool SetPointLocation(const int a_pointIdx, const Pt3d& a_point) override;
 
   virtual Pt3d GetPointXy0(const int a_pointIdx) const override;
   virtual VecPt3d GetPointsLocations(const VecInt& a_points) const override;
@@ -83,6 +87,8 @@ public:
   virtual void GetPointsAdjacentCells(const int a_pointIdx1,
                                       const int a_pointIdx2,
                                       VecInt& a_commonCellIdxs) const override;
+  virtual bool IsValidPointChange(const int a_changedPtIdx,
+                                  const Pt3d& a_newPosition) const override;
 
   // Cells
   virtual int GetCellCount() const override;
@@ -150,6 +156,12 @@ private:
   void UpdateCellLinks();
   void UpdatePointLinks();
 
+  void SetModified();
+
+  bool IsCellValidWithPointChange(const int a_cellIdx,
+                                  const int a_changedPtIdx,
+                                  const Pt3d& a_newPosition) const;
+
   static int DimensionFromCellType(const XmUGridCellType a_cellType);
 
   int GetNumberOfItemsForCell(const int a_cellIdx) const;
@@ -176,9 +188,6 @@ private:
 
   bool IsFaceSide(const VecInt& a_facePts) const;               // plan view
   bool GetCellXySegments(int cellIdx, VecPt3d& segments) const; // plan view
-  bool IsCellValidWithPointChange(const int a_cellIdx,
-                                  const int a_changedPtIdx,
-                                  const Pt3d& a_newPosition) const;
   void GetEdgesOfFace(const VecInt& a_face, std::vector<XmEdge>& a_edges) const;
   bool DoEdgesCrossWithPointChange(const int a_changedPtIdx,
                                    const Pt3d& a_newPosition,
@@ -193,6 +202,7 @@ private:
                                     ///< of cells)
   VecInt m_pointIdxToPointsToCells; ///< Indexes for each point in array of
                                     ///< points cells
+  bool m_modified = 0; ///< True if UGrid has been modified since last SetUnmodified call
 };
 
 namespace
@@ -625,8 +635,8 @@ bool gmEqualPointsXY(double x1, double y1, double x2, double y2, double toleranc
 /// \param x x coord of point to test
 /// \param y y coord of point to test
 /// \param tol tolerance for geometric comparison
-/// \return  Returns true if the PointLocation is on the line passing through p1 and p2
-///          within the tolerance passed.
+/// \return  Returns true if the GetPointLocation is on the line passing through
+///          p1 and p2 within the tolerance passed.
 /// \note: you should always be careful to consider the case when p1 and
 ///          p2 are very close to each other but not to x,y.  in that case this
 ///          test will almost always fail because it will be more susceptible to
@@ -830,15 +840,37 @@ void iMergeSegmentsToPoly(const VecPt3d& segments, VecPt3d& polygon)
 XmUGridImpl::XmUGridImpl()
 {
 } // XmUGridImpl::XmUGridImpl
-// Locations
+//------------------------------------------------------------------------------
+/// \brief Returns the modified flag. Gets set when points or cells get changed.
+/// \return the modified flag
+//------------------------------------------------------------------------------
+bool XmUGridImpl::GetModified() const
+{
+  return m_modified;
+} // XmUGridImpl::GetModified
+//------------------------------------------------------------------------------
+/// \brief Resets the modified flag to false.
+//------------------------------------------------------------------------------
+void XmUGridImpl::SetUnmodified()
+{
+  m_modified = false;
+} // XmUGridImpl::SetUnmodified
+//------------------------------------------------------------------------------
+/// \brief Sets the modified flag to true.
+//------------------------------------------------------------------------------
+void XmUGridImpl::SetModified()
+{
+  m_modified = true;
+} // XmUGridImpl::SetModified
+// Points
 //------------------------------------------------------------------------------
 /// \brief Get the number of points.
 /// \return the number of points
 //------------------------------------------------------------------------------
-int XmUGridImpl::PointCount() const
+int XmUGridImpl::GetPointCount() const
 {
   return (int)m_points.size();
-} // XmUGridImpl::PointCount
+} // XmUGridImpl::GetPointCount
 //------------------------------------------------------------------------------
 /// \brief Get vector of UGrid points.
 /// \return constant reference to vector of points
@@ -854,6 +886,7 @@ const VecPt3d& XmUGridImpl::GetLocations() const
 void XmUGridImpl::SetLocations(const VecPt3d& a_locations)
 {
   m_points = a_locations;
+  SetModified();
 } // XmUGridImpl::SetLocations
 //------------------------------------------------------------------------------
 /// \brief Get the point
@@ -872,29 +905,16 @@ Pt3d XmUGridImpl::GetPointLocation(const int a_pointIdx) const
 /// \param[in] a_location The new location of the specified point
 /// \return whether the point was successfully set
 //------------------------------------------------------------------------------
-bool XmUGridImpl::SetLocation(const int a_pointIdx, const Pt3d& a_location)
+bool XmUGridImpl::SetPointLocation(const int a_pointIdx, const Pt3d& a_location)
 {
   if (a_pointIdx >= 0 && a_pointIdx < m_points.size())
   {
-    VecInt affectedCells = GetPointAdjacentCells(a_pointIdx);
-    bool badCell = false;
-    for (int i(0); i < affectedCells.size(); i++)
-    {
-      if (!IsCellValidWithPointChange(affectedCells[i], a_pointIdx, a_location))
-      {
-        badCell = true;
-        break;
-      }
-    }
-    if (!badCell)
-    {
-      m_points[a_pointIdx] = a_location;
-      return true;
-    }
-    return false;
+    m_points[a_pointIdx] = a_location;
+    SetModified();
+    return true;
   }
   return false;
-} // XmUGridImpl::SetLocation
+} // XmUGridImpl::SetPointLocation
 
 //------------------------------------------------------------------------------
 /// \brief Get the X, Y location of a point.
@@ -1235,6 +1255,7 @@ bool XmUGridImpl::SetCellstream(const VecInt& a_cellstream)
   {
     m_cellstream = a_cellstream;
     UpdateLinks();
+    SetModified();
     return true;
   }
   else
@@ -1359,14 +1380,13 @@ bool XmUGridImpl::GetCellCentroid(int a_cellIdx, Pt3d& a_centroid) const
   a_centroid = centroid;
   return retVal;
 } // XmUGridImpl::GetCellCentroid
-
-//------------------------------------------------------------------------------
-/// \brief Determine whether a cell is valid after a point is moved.
-/// \param[in] a_cellIdx the index of the cell
-/// \param[in] a_changedPtIdx index of the point to be changed
-/// \param[in] a_newPosition location the point is to be moved to
-/// \return whether the cell is valid
-//------------------------------------------------------------------------------
+  //------------------------------------------------------------------------------
+  /// \brief Determine whether a cell is valid after a point is moved.
+  /// \param[in] a_cellIdx the index of the cell
+  /// \param[in] a_changedPtIdx index of the point to be changed
+  /// \param[in] a_newPosition location the point is to be moved to
+  /// \return whether the cell is valid
+  //------------------------------------------------------------------------------
 bool XmUGridImpl::IsCellValidWithPointChange(const int a_cellIdx,
                                              const int a_changedPtIdx,
                                              const Pt3d& a_newPosition) const
@@ -1402,6 +1422,30 @@ bool XmUGridImpl::IsCellValidWithPointChange(const int a_cellIdx,
   }
   return true;
 } // XmUGridImpl::IsCellValidWithPointChange
+//------------------------------------------------------------------------------
+/// \brief Determine whether adjacent cells are valid after a point is moved.
+/// \param[in] a_changedPtIdx index of the point to be changed
+/// \param[in] a_newPosition location the point is to be moved to
+/// \return whether the change is valid
+//------------------------------------------------------------------------------
+bool XmUGridImpl::IsValidPointChange(const int a_changedPtIdx, const Pt3d& a_newPosition) const
+{
+  bool validChange = false;
+  if (a_changedPtIdx >= 0 && a_changedPtIdx < m_points.size())
+  {
+    validChange = true;
+    VecInt affectedCells = GetPointAdjacentCells(a_changedPtIdx);
+    for (int i(0); i < affectedCells.size(); i++)
+    {
+      if (!IsCellValidWithPointChange(affectedCells[i], a_changedPtIdx, a_newPosition))
+      {
+        validChange = false;
+        break;
+      }
+    }
+  }
+  return validChange;
+} // XmUGridImpl::IsValidPointChange
 //------------------------------------------------------------------------------
 /// \brief Get the edges of a cell given a face
 /// \param[in] a_face a vector of point indices of a face
@@ -2627,9 +2671,10 @@ bool XmUGridImpl::GetFaceXySegments(int a_cellIdx, int a_faceIdx, VecPt3d& a_seg
 ///
 /// Functions that return the number of objects in some scope end with the word
 /// "Count" preceded by the type of things being counted and optionally a
-/// scope. So PointCount() and GetCellCount() return the number of points and cells
-/// respectively in the XmUGrid, while GetCellPointCount() and GetCellEdgeCount()
-/// return the number of points or edges, respectively, in a specified cell.
+/// scope. So GetPointCount() and GetCellCount() return the number of points and
+/// cells respectively in the XmUGrid, while GetCellPointCount() and
+/// GetCellEdgeCount() return the number of points or edges, respectively, in a
+/// specified cell.
 ///
 /// There is a predefined ordering of faces within the solid cell types, so
 /// faceIdx refers to the face in that ordering. Methods containing the words
@@ -3218,13 +3263,18 @@ void XmUGridUnitTests::testUGridStreams()
   // Cell type (9), number of points (4), point numbers, counterclockwise
   cellstream = {9, 4, 0, 3, 4, 1, 9, 4, 1, 4, 5, 2, 9, 4, 3, 6, 7, 4, 9, 4, 4, 7, 8, 5};
 
+  TS_ASSERT(!ugrid->GetModified());
   ugrid->SetLocations(points);
   VecPt3d pointsOut = ugrid->GetLocations();
   TS_ASSERT_EQUALS(points, pointsOut);
+  TS_ASSERT(ugrid->GetModified());
 
+  ugrid->SetUnmodified();
+  TS_ASSERT(!ugrid->GetModified());
   TS_ASSERT(ugrid->SetCellstream(cellstream));
   VecInt cellstreamOut = ugrid->GetCellStream();
   TS_ASSERT_EQUALS(cellstream, cellstreamOut);
+  TS_ASSERT(ugrid->GetModified());
 
   // Test invalid cell streams
   cellstream = {-1};
@@ -3269,12 +3319,17 @@ void XmUGridUnitTests::testGetSetPoint()
   }
   TS_ASSERT_EQUALS(Pt3d(10, 10, 0), ugrid->GetPointXy0(1));
   TS_ASSERT_EQUALS(Pt3d(), ugrid->GetPointLocation((int)points.size()));
+  TS_ASSERT(ugrid->GetModified());
 
-  TS_ASSERT(!ugrid->SetLocation(-1, Pt3d()));
-  TS_ASSERT(!ugrid->SetLocation((int)points.size(), Pt3d()));
+  ugrid->SetUnmodified();
+  TS_ASSERT(!ugrid->GetModified());
+  TS_ASSERT(!ugrid->SetPointLocation(-1, Pt3d()));
+  TS_ASSERT(!ugrid->SetPointLocation((int)points.size(), Pt3d()));
+  TS_ASSERT(!ugrid->GetModified());
 
-  TS_ASSERT(ugrid->SetLocation(0, Pt3d(-10, 10, 0)));
+  TS_ASSERT(ugrid->SetPointLocation(0, Pt3d(-10, 10, 0)));
   TS_ASSERT_EQUALS(Pt3d(-10, 10, 0), ugrid->GetPointLocation(0));
+  TS_ASSERT(ugrid->GetModified());
 } // XmUGridUnitTests::testGetSetPoint
 //------------------------------------------------------------------------------
 /// \brief Test Getting a cell stream.
@@ -3327,7 +3382,7 @@ void XmUGridUnitTests::testGetCellType()
     TS_FAIL("Unable to create UGrid.");
     return;
   }
-  TS_ASSERT_EQUALS(14, ugrid2d->PointCount());
+  TS_ASSERT_EQUALS(14, ugrid2d->GetPointCount());
   TS_ASSERT_EQUALS(6, ugrid2d->GetCellCount());
   TS_ASSERT_EQUALS(XMU_INVALID_CELL_TYPE, ugrid2d->GetCellType(-1));
   TS_ASSERT_EQUALS(XMU_INVALID_CELL_TYPE, ugrid2d->GetCellType(6));
@@ -3344,7 +3399,7 @@ void XmUGridUnitTests::testGetCellType()
     TS_FAIL("Unable to create UGrid.");
     return;
   }
-  TS_ASSERT_EQUALS(30, ugrid3d->PointCount());
+  TS_ASSERT_EQUALS(30, ugrid3d->GetPointCount());
   TS_ASSERT_EQUALS(6, ugrid3d->GetCellCount());
   TS_ASSERT_EQUALS(XMU_INVALID_CELL_TYPE, ugrid3d->GetCellType(-1));
   TS_ASSERT_EQUALS(XMU_INVALID_CELL_TYPE, ugrid3d->GetCellType(6));
@@ -3913,11 +3968,11 @@ void XmUGridUnitTests::testGetPointsAdjacentCells()
   points.clear();
   retrievedCells.clear();
 
-  points = {ugrid->PointCount(), 0};
+  points = {ugrid->GetPointCount(), 0};
   retrievedCells = ugrid->GetPointsAdjacentCells(points);
   TS_ASSERT_EQUALS(expectedCells, retrievedCells);
 
-  points = {0, ugrid->PointCount()};
+  points = {0, ugrid->GetPointCount()};
   retrievedCells = ugrid->GetPointsAdjacentCells(points);
   TS_ASSERT_EQUALS(expectedCells, retrievedCells);
 
@@ -4105,7 +4160,7 @@ void XmUGridUnitTests::testEdgeAdjacentCells()
     TS_ASSERT_EQUALS(expectedCells[i], adjacentCells);
   }
 
-  XmEdge badEdge(0, ugrid->PointCount());
+  XmEdge badEdge(0, ugrid->GetPointCount());
   adjacentCells = ugrid->GetEdgeAdjacentCells(badEdge);
   TS_ASSERT_EQUALS(expectedFail, adjacentCells);
 
@@ -4506,21 +4561,25 @@ void XmUGridUnitTests::testIsCellValidWithPointChange()
     return;
   }
 
-  Pt3d valid = {5.0, 5.0, 0.0};
+  Pt3d validPt = {5.0, 5.0, 0.0};
   Pt3d invalid = {500.0, 500.0, 0.0};
 
-  TS_ASSERT(ugrid->SetLocation(4, valid));
-  TS_ASSERT(!ugrid->SetLocation(4, invalid));
+  TS_ASSERT(ugrid->IsValidPointChange(4, validPt));
+  TS_ASSERT(!ugrid->IsValidPointChange(4, invalid));
 
   BSHP<XmUGrid> ugrid3d = TEST_XmUBuildHexahedronUgrid(4, 4, 4);
 
-  valid = ugrid3d->GetPointLocation(21);
-  valid.x += 0.5;
-  valid.y += 0.5;
-  valid.z += 0.5;
-  TS_ASSERT(ugrid3d->SetLocation(21, valid));
-  TS_ASSERT(!ugrid3d->SetLocation(21, invalid));
+  validPt = ugrid3d->GetPointLocation(21);
+  validPt.x += 0.5;
+  validPt.y += 0.5;
+  validPt.z += 0.5;
+  TS_ASSERT(ugrid3d->IsValidPointChange(21, validPt));
+  TS_ASSERT(!ugrid3d->IsValidPointChange(21, invalid));
 
+  TS_ASSERT(ugrid->SetPointLocation(4, validPt));
+  TS_ASSERT(ugrid->SetPointLocation(4, invalid));
+  TS_ASSERT(ugrid3d->SetPointLocation(21, validPt));
+  TS_ASSERT(ugrid3d->SetPointLocation(21, invalid));
 } // XmUGridUnitTests::testIsCellValidWithPointChange
 
 //! [snip_test_PointFunctions]
@@ -4536,8 +4595,8 @@ void XmUGridUnitTests::testPointFunctions()
     return;
   }
 
-  // Test PointCount
-  TS_ASSERT_EQUALS(ugrid->PointCount(), 9);
+  // Test GetPointCount
+  TS_ASSERT_EQUALS(ugrid->GetPointCount(), 9);
   VecPt3d points = {{0, 10, 0}, {10, 10, 0}, {20, 10, 0},  {0, 0, 0},   {10, 0, 0},
                     {20, 0, 0}, {0, -10, 0}, {10, -10, 0}, {20, -10, 0}};
 
@@ -4548,12 +4607,11 @@ void XmUGridUnitTests::testPointFunctions()
     TS_ASSERT_EQUALS(points[i], ugrid->GetPointLocation(i));
   }
 
-  // Test SetLocation & PointLocation
+  // Test SetPointLocation & GetPointLocation
   Pt3d invalid = {100, 100, 100};
   Pt3d valid = {5, 5, 5};
-  TS_ASSERT(!ugrid->SetLocation(4, invalid));
-  TS_ASSERT_EQUALS(points[4], ugrid->GetPointLocation(4));
-  TS_ASSERT(ugrid->SetLocation(4, valid));
+  TS_ASSERT(!ugrid->IsValidPointChange(4, invalid));
+  TS_ASSERT(ugrid->SetPointLocation(4, valid));
   TS_ASSERT_EQUALS(valid, ugrid->GetPointLocation(4));
 
   VecInt pointIndices = {0, 3, 6};

--- a/xmsgrid/ugrid/XmUGrid.h
+++ b/xmsgrid/ugrid/XmUGrid.h
@@ -124,13 +124,20 @@ public:
   virtual ~XmUGrid();
 
   // Misc
+  /// \brief Returns the modified flag. Gets set when points or cells get changed.
+  /// \return the modified flag
+  virtual bool GetModified() const = 0;
+
+  /// \brief Resets the modified flag to false.
+  virtual void SetUnmodified() = 0;
+
   static bool IsValidCellstream(const VecInt& a_cellstream);
 
   // Points
 
   /// \brief Get the number of points.
   /// \return the number of points
-  virtual int PointCount() const = 0;
+  virtual int GetPointCount() const = 0;
 
   /// \brief Get vector of UGrid points.
   /// \return a vector of point locations
@@ -149,7 +156,7 @@ public:
   /// \param[in] a_pointIdx the index of the point
   /// \param[in] a_location The new location of the specified point
   /// \return whether the point was successfully set
-  virtual bool SetLocation(const int a_pointIdx, const Pt3d& a_location) = 0;
+  virtual bool SetPointLocation(const int a_pointIdx, const Pt3d& a_location) = 0;
 
   /// \brief Get the X, Y location of a point.
   /// \param[in] a_pointIdx The index of the point.
@@ -195,6 +202,12 @@ public:
   virtual void GetPointsAdjacentCells(const int a_pointIdx1,
                                       const int a_pointIdx2,
                                       VecInt& a_adjacentCellIdxs) const = 0;
+
+  /// \brief Determine whether adjacent cells are valid after a point is moved.
+  /// \param[in] a_changedPtIdx index of the point to be changed
+  /// \param[in] a_newPosition location the point is to be moved to
+  /// \return whether the change is valid
+  virtual bool IsValidPointChange(const int a_changedPtIdx, const Pt3d& a_newPosition) const = 0;
 
   // Cells
 

--- a/xmsgrid/ugrid/XmUGridUtils.cpp
+++ b/xmsgrid/ugrid/XmUGridUtils.cpp
@@ -718,6 +718,6 @@ void XmUGridUtilsTests::testWriteThenReadUGridFileToAscii()
   TS_ASSERT_EQUALS(ugridBase->GetLocations(), ugridOut->GetLocations());
   TS_ASSERT_EQUALS(ugridBase->GetCellStream(), ugridOut->GetCellStream());
 } // XmUGridUtilsTests::testWriteThenReadUGridFile
-//! [snip_test_WriteReadAscii]
+  //! [snip_test_WriteReadAscii]
 
 #endif


### PR DESCRIPTION
Changed XmUGrid::SetLocation to not check for valid cells. Instead must call IsValidPointChange to check if the change is valid.
Changed XmUGrid::PointCount to GetPointCount.
Changed XmUGrid::SetLocation to SetPointLocation.
Added python binding to see if two edges are equivalent.