### PR TITLE
fix crash with less than 3 points in gmPolygonArea

### DIFF
--- a/xmsgrid/geometry/geoms.cpp
+++ b/xmsgrid/geometry/geoms.cpp
@@ -1536,6 +1536,8 @@ bool gmInsideOrOnLineWithTol(const Pt3d* p1,
 //------------------------------------------------------------------------------
 double gmPolygonArea(const Pt3d* pts, size_t npoints)
 {
+  if (npoints < 3)
+    return 0.0;
   size_t id;
   double area = 0.0;
 


### PR DESCRIPTION
fix crash with less than 3 points in gmPolygonArea