### PR TITLE
Traverse line segment fix

### DIFF
--- a/_package/xms/grid/__init__.py
+++ b/_package/xms/grid/__init__.py
@@ -2,4 +2,4 @@ from . import geometry
 from . import triangulate
 from . import ugrid
 
-__version__ = '4.2.1'
+__version__ = '4.2.2'

--- a/_package/xms/grid/__init__.py
+++ b/_package/xms/grid/__init__.py
@@ -2,4 +2,4 @@ from . import geometry
 from . import triangulate
 from . import ugrid
 
-__version__ = '4.2.2'
+__version__ = '4.2.3'

--- a/dev/xmsprofile_debug
+++ b/dev/xmsprofile_debug
@@ -7,7 +7,8 @@ compiler=Visual Studio
 compiler.version=12
 build_type=Debug
 [options]
-xmscore:xms=True
-xmsgrid:xms=True
+xmsgrid:xms=False
+xmsgrid:pybind=False
+xmsgrid:testing=True
 [build_requires]
 [env]

--- a/xmsgrid/geometry/GmMultiPolyIntersector.cpp
+++ b/xmsgrid/geometry/GmMultiPolyIntersector.cpp
@@ -25,17 +25,18 @@
 #pragma warning(pop)
 
 // 5. Shared code headers
+#include <xmscore/math/math.h> // GTEQ_TOL
 #include <xmscore/misc/XmConst.h>
 #include <xmscore/misc/XmError.h> // XM_ASSERT
 #include <xmscore/misc/XmLog.h>
-#include <xmscore/misc/boost_defines.h>      // BSHP
-#include <xmscore/misc/xmstype.h>            // XM_NODATA
-#include <xmscore/points/pt.h>               // Pt3d
-#include <xmscore/stl/set.h>                 // Set*
-#include <xmscore/stl/vector.h>              // Vec*
-#include <xmsgrid/geometry/GmBoostTypes.h> // GmBstPoly3d, XmBstRing
+#include <xmscore/misc/boost_defines.h>                     // BSHP
+#include <xmscore/misc/xmstype.h>                           // XM_NODATA
+#include <xmscore/points/pt.h>                              // Pt3d
+#include <xmscore/stl/set.h>                                // Set*
+#include <xmscore/stl/vector.h>                             // Vec*
+#include <xmsgrid/geometry/GmBoostTypes.h>                  // GmBstPoly3d, XmBstRing
 #include <xmsgrid/geometry/GmMultiPolyIntersectionSorter.h> // GmMultiPolyIntersectionSorter
-#include <xmsgrid/geometry/GmMultiPolyIntersectorData.h> // GmMultiPolyIntersectorData
+#include <xmsgrid/geometry/GmMultiPolyIntersectorData.h>    // GmMultiPolyIntersectorData
 #include <xmsgrid/geometry/geoms.h> // gmPolygonArea, gmAddToExtents, gmXyDistance
 
 //----- Forward declarations ---------------------------------------------------
@@ -47,66 +48,83 @@ namespace bgi = boost::geometry::index;
 
 //----- Namespace declaration --------------------------------------------------
 
-namespace xms {
+namespace xms
+{
 //----- Constants / Enumerations -----------------------------------------------
 
 // Typedefs
-typedef std::pair<GmBstBox3d, int> ValueBox; ///< Pair used in rtree
+typedef std::pair<GmBstBox3d, int> ValueBox;              ///< Pair used in rtree
 typedef bgi::rtree<ValueBox, bgi::quadratic<8>> RtreeBox; ///< Rtree typedef
 
 //----- Classes / Structs ------------------------------------------------------
 
 ////////////////////////////////////////////////////////////////////////////////
-class GmMultiPolyIntersectorImpl : public GmMultiPolyIntersector {
+class GmMultiPolyIntersectorImpl : public GmMultiPolyIntersector
+{
 public:
-  GmMultiPolyIntersectorImpl(const VecPt3d &a_points, const VecInt2d &a_polys,
+  GmMultiPolyIntersectorImpl(const VecPt3d& a_points,
+                             const VecInt2d& a_polys,
                              BSHP<GmMultiPolyIntersectionSorter> a_sorter,
                              int a_startingId = 1);
   virtual ~GmMultiPolyIntersectorImpl();
 
   virtual void SetQuery(GmMultiPolyIntersectorQueryEnum a_query) override;
-  virtual void TraverseLineSegment(double a_x1, double a_y1, double a_x2, double a_y2,
-                                   VecInt &a_polyids, VecDbl &a_tvalues) override;
-  virtual void TraverseLineSegment(double a_x1, double a_y1, double a_x2, double a_y2,
-                                   VecInt &a_polyids) override;
-  virtual void TraverseLineSegment(double a_x1, double a_y1, double a_x2,
-                                   double a_y2, VecInt &a_polyids,
-                                   std::vector<Pt3d> &a_pts) override;
-  virtual void TraverseLineSegment(double a_x1, double a_y1, double a_x2,
-                                   double a_y2, VecInt &a_polyids, VecDbl &a_tvalues,
-                                   std::vector<Pt3d> &a_pts) override;
-  virtual int PolygonFromPoint(const Pt3d &a_pt) override;
+  virtual void TraverseLineSegment(double a_x1,
+                                   double a_y1,
+                                   double a_x2,
+                                   double a_y2,
+                                   VecInt& a_polyIds,
+                                   VecDbl& a_tValues) override;
+  virtual void TraverseLineSegment(double a_x1,
+                                   double a_y1,
+                                   double a_x2,
+                                   double a_y2,
+                                   VecInt& a_polyIds) override;
+  virtual void TraverseLineSegment(double a_x1,
+                                   double a_y1,
+                                   double a_x2,
+                                   double a_y2,
+                                   VecInt& a_polyIds,
+                                   VecPt3d& a_pts) override;
+  virtual void TraverseLineSegment(double a_x1,
+                                   double a_y1,
+                                   double a_x2,
+                                   double a_y2,
+                                   VecInt& a_polyIds,
+                                   VecDbl& a_tValues,
+                                   VecPt3d& a_pts) override;
+  virtual int PolygonFromPoint(const Pt3d& a_pt) override;
 
 private:
+  void RemoveDuplicateTValues(VecInt& a_polyIds, VecDbl& a_tValues, VecPt3d& a_pts);
   void CalculateBuffer();
-  void BufferTheBox(GmBstBox3d &box) const;
-  GmBstPoly3d &GetBoostPoly(int a_polyIdx);
-  void BuildBoostPoly(int a_polyIdx, GmBstPoly3d &a_boostPoly) const;
+  void BufferTheBox(GmBstBox3d& box) const;
+  GmBstPoly3d& GetBoostPoly(int a_polyIdx);
+  void BuildBoostPoly(int a_polyIdx, GmBstPoly3d& a_boostPoly) const;
   void BuildRTree();
   void CreateLine();
-  void GetPolysForPoint(Pt3d pt, SetInt &poly);
+  void GetPolysForPoint(Pt3d pt, SetInt& poly);
   void EnsureEndPointsRepresented();
   void IntersectEachPolyWithLine();
   void ComputeTValues();
   void SortIntersections();
-  void OffsetPolyIds(VecInt &polyIds) const;
-  void PointsOnSegment(const GmBstPoly3d &a_poly, const GmBstLine3d &a_line,
-                       std::deque<Pt3d> &a_output);
+  void OffsetPolyIds(VecInt& polyIds) const;
+  void PointsOnSegment(const GmBstPoly3d& a_poly,
+                       const GmBstLine3d& a_line,
+                       std::deque<Pt3d>& a_output);
   // void ValidatePolygons ();
 
-  GmMultiPolyIntersectorData m_d; ///< Point and poly data.
-  Pt3d m_pt1;                     ///< 1st line segment point
-  Pt3d m_pt2;                     ///< 2nd line segment point
-  RtreeBox *m_rtree;              ///< Rtree used to find polygons
-  GmBstLine3d m_line;             ///< Current line segment
-  double m_buffer;                ///< Small buffer around each bounding box
-  int m_startingId; ///< Offset if polys start at something other than one
+  GmMultiPolyIntersectorData m_d;        ///< Point and poly data.
+  Pt3d m_pt1;                            ///< 1st line segment point
+  Pt3d m_pt2;                            ///< 2nd line segment point
+  RtreeBox* m_rtree;                     ///< Rtree used to find polygons
+  GmBstLine3d m_line;                    ///< Current line segment
+  double m_buffer;                       ///< Small buffer around each bounding box
+  int m_startingId;                      ///< Offset if polys start at something other than one
   std::vector<GmBstPoly3d> m_boostPolys; ///< Polygons as boost geom polygons
-  BSHP<GmMultiPolyIntersectionSorter>
-      m_sorter; ///< Sorter used to process results
-  GmMultiPolyIntersectorQueryEnum
-      m_query; ///< Type of query (intersect, covered by...)
-};             // class GmMultiPolyIntersectorImpl
+  BSHP<GmMultiPolyIntersectionSorter> m_sorter; ///< Sorter used to process results
+  GmMultiPolyIntersectorQueryEnum m_query;      ///< Type of query (intersect, covered by...)
+};                                              // class GmMultiPolyIntersectorImpl
 
 //----- Class / Function definitions -------------------------------------------
 
@@ -117,12 +135,14 @@ private:
 //------------------------------------------------------------------------------
 /// \brief
 //------------------------------------------------------------------------------
-GmMultiPolyIntersector::GmMultiPolyIntersector() {
+GmMultiPolyIntersector::GmMultiPolyIntersector()
+{
 } // GmMultiPolyIntersector::GmMultiPolyIntersector
 //------------------------------------------------------------------------------
 /// \brief
 //------------------------------------------------------------------------------
-GmMultiPolyIntersector::~GmMultiPolyIntersector() {
+GmMultiPolyIntersector::~GmMultiPolyIntersector()
+{
 } // GmMultiPolyIntersector::~GmMultiPolyIntersector
 //------------------------------------------------------------------------------
 /// \brief Creates a new GmMultiPolyIntersectorImpl object.
@@ -135,13 +155,14 @@ GmMultiPolyIntersector::~GmMultiPolyIntersector() {
 ///                       than 1, specify the starting value.
 /// \return GmMultiPolyIntersector.
 //------------------------------------------------------------------------------
-BSHP<GmMultiPolyIntersector>
-GmMultiPolyIntersector::New(const VecPt3d &a_points, const VecInt2d &a_polys,
-                            BSHP<GmMultiPolyIntersectionSorter> a_sorter,
-                            int a_startingId /*=1*/) {
-  return BDPC<GmMultiPolyIntersector>(
-      BSHP<GmMultiPolyIntersectorImpl>(new GmMultiPolyIntersectorImpl(
-          a_points, a_polys, a_sorter, a_startingId)));
+BSHP<GmMultiPolyIntersector> GmMultiPolyIntersector::New(
+  const VecPt3d& a_points,
+  const VecInt2d& a_polys,
+  BSHP<GmMultiPolyIntersectionSorter> a_sorter,
+  int a_startingId /*=1*/)
+{
+  return BDPC<GmMultiPolyIntersector>(BSHP<GmMultiPolyIntersectorImpl>(
+    new GmMultiPolyIntersectorImpl(a_points, a_polys, a_sorter, a_startingId)));
 } // GmMultiPolyIntersector::GmMultiPolyIntersector
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -160,12 +181,21 @@ GmMultiPolyIntersector::New(const VecPt3d &a_points, const VecInt2d &a_polys,
 /// \param a_startingId: If the polygon IDs should start at something other
 ///                       than 1, specify the starting value.
 //------------------------------------------------------------------------------
-GmMultiPolyIntersectorImpl::GmMultiPolyIntersectorImpl(
-    const VecPt3d &a_points, const VecInt2d &a_polys,
-    BSHP<GmMultiPolyIntersectionSorter> a_sorter, int a_startingId /*=1*/)
-    : m_d(), m_pt1(), m_pt2(), m_rtree(nullptr), m_line(), m_buffer(0.0),
-      m_startingId(a_startingId), m_boostPolys(), m_sorter(a_sorter),
-      m_query(GMMPIQ_COVEREDBY) {
+GmMultiPolyIntersectorImpl::GmMultiPolyIntersectorImpl(const VecPt3d& a_points,
+                                                       const VecInt2d& a_polys,
+                                                       BSHP<GmMultiPolyIntersectionSorter> a_sorter,
+                                                       int a_startingId /*=1*/)
+: m_d()
+, m_pt1()
+, m_pt2()
+, m_rtree(nullptr)
+, m_line()
+, m_buffer(0.0)
+, m_startingId(a_startingId)
+, m_boostPolys()
+, m_sorter(a_sorter)
+, m_query(GMMPIQ_COVEREDBY)
+{
   m_d.m_points = a_points;
 
   m_d.m_polys = a_polys;
@@ -179,7 +209,8 @@ GmMultiPolyIntersectorImpl::GmMultiPolyIntersectorImpl(
 //------------------------------------------------------------------------------
 /// \brief
 //------------------------------------------------------------------------------
-GmMultiPolyIntersectorImpl::~GmMultiPolyIntersectorImpl() {
+GmMultiPolyIntersectorImpl::~GmMultiPolyIntersectorImpl()
+{
   if (m_rtree)
     delete (m_rtree);
 } // GmMultiPolyIntersectorImpl::GmMultiPolyIntersectorImpl
@@ -202,11 +233,14 @@ GmMultiPolyIntersectorImpl::~GmMultiPolyIntersectorImpl() {
 /// \brief Calculate a small buffer distance by which we expand all polygon
 ///        bounding boxes.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::CalculateBuffer() {
+void GmMultiPolyIntersectorImpl::CalculateBuffer()
+{
   // Get min/max of all polys
   Pt3d mn(XM_DBL_HIGHEST), mx(XM_DBL_LOWEST);
-  for (size_t i = 0; i < m_d.m_polys.size(); ++i) {
-    for (size_t j = 0; j < m_d.m_polys[i].size(); ++j) {
+  for (size_t i = 0; i < m_d.m_polys.size(); ++i)
+  {
+    for (size_t j = 0; j < m_d.m_polys[i].size(); ++j)
+    {
       gmAddToExtents(m_d.m_points[m_d.m_polys[i][j]], mn, mx);
     }
   }
@@ -223,7 +257,8 @@ void GmMultiPolyIntersectorImpl::CalculateBuffer() {
 ///        working correctly, it's the best idea we've got.
 /// \param box: The box.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::BufferTheBox(GmBstBox3d &box) const {
+void GmMultiPolyIntersectorImpl::BufferTheBox(GmBstBox3d& box) const
+{
   box.min_corner().x -= m_buffer;
   box.min_corner().y -= m_buffer;
   box.max_corner().x += m_buffer;
@@ -234,8 +269,10 @@ void GmMultiPolyIntersectorImpl::BufferTheBox(GmBstBox3d &box) const {
 /// \param a_polyIdx: The polygon index.
 /// \return GmBstPoly3d.
 //------------------------------------------------------------------------------
-GmBstPoly3d &GmMultiPolyIntersectorImpl::GetBoostPoly(int a_polyIdx) {
-  if (m_boostPolys[a_polyIdx].outer().empty()) {
+GmBstPoly3d& GmMultiPolyIntersectorImpl::GetBoostPoly(int a_polyIdx)
+{
+  if (m_boostPolys[a_polyIdx].outer().empty())
+  {
     // if (bg::exterior_ring(m_boostPolys[a_polyIdx]).empty()) {
     BuildBoostPoly(a_polyIdx, m_boostPolys[a_polyIdx]);
   }
@@ -246,10 +283,11 @@ GmBstPoly3d &GmMultiPolyIntersectorImpl::GetBoostPoly(int a_polyIdx) {
 /// \param a_polyIdx: The polygon index.
 /// \param a_boostPoly: GmBstPoly3d.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::BuildBoostPoly(
-    int a_polyIdx, GmBstPoly3d &a_boostPoly) const {
-  const VecInt &poly = m_d.m_polys[a_polyIdx];
-  for (int j = 0; j < (int)poly.size(); ++j) {
+void GmMultiPolyIntersectorImpl::BuildBoostPoly(int a_polyIdx, GmBstPoly3d& a_boostPoly) const
+{
+  const VecInt& poly = m_d.m_polys[a_polyIdx];
+  for (int j = 0; j < (int)poly.size(); ++j)
+  {
     Pt3d pt = m_d.m_points[poly[j]];
     bg::exterior_ring(a_boostPoly).push_back(m_d.m_points[poly[j]]);
   }
@@ -258,7 +296,8 @@ void GmMultiPolyIntersectorImpl::BuildBoostPoly(
 //------------------------------------------------------------------------------
 /// \brief Create a boost rtree of polygon extents.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::BuildRTree() {
+void GmMultiPolyIntersectorImpl::BuildRTree()
+{
   // Changed to use the packing algorithm. See:
   // http://www.boost.org/doc/libs/1_55_0/libs/geometry/doc/html/geometry/spatial_indexes/introduction.html
   // We thought this would make it faster but according to the test
@@ -271,9 +310,11 @@ void GmMultiPolyIntersectorImpl::BuildRTree() {
   // m_rtree = new RtreeBox(); // Non packing algorithm
   std::vector<ValueBox> boxen; // Packing algorithm
 
-  for (int i = 0; i < (int)m_d.m_polys.size(); ++i) {
+  for (int i = 0; i < (int)m_d.m_polys.size(); ++i)
+  {
     Pt3d mn(XM_DBL_HIGHEST), mx(XM_DBL_LOWEST);
-    for (int j = 0; j < (int)m_d.m_polys[i].size(); ++j) {
+    for (int j = 0; j < (int)m_d.m_polys[i].size(); ++j)
+    {
       gmAddToExtents(m_d.m_points[m_d.m_polys[i][j]], mn, mx);
     }
     GmBstBox3d box(mn, mx);
@@ -289,7 +330,8 @@ void GmMultiPolyIntersectorImpl::BuildRTree() {
 //------------------------------------------------------------------------------
 /// \brief Creates a boost geom line of the current line segment.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::CreateLine() {
+void GmMultiPolyIntersectorImpl::CreateLine()
+{
   m_line.push_back(m_pt1);
   m_line.push_back(m_pt2);
 } // GmMultiPolyIntersectorImpl::CreateLine
@@ -297,8 +339,8 @@ void GmMultiPolyIntersectorImpl::CreateLine() {
 /// \brief Set the query to use (covered by, intersects...).
 /// \param a_query: GmMultiPolyIntersectorQueryEnum
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::SetQuery(
-    GmMultiPolyIntersectorQueryEnum a_query) {
+void GmMultiPolyIntersectorImpl::SetQuery(GmMultiPolyIntersectorQueryEnum a_query)
+{
   m_query = a_query;
 } // GmMultiPolyIntersectorImpl::SetQuery
 //------------------------------------------------------------------------------
@@ -306,16 +348,19 @@ void GmMultiPolyIntersectorImpl::SetQuery(
 /// \param pt: point loction
 /// \param a_poly: 1-based polygon ID.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::GetPolysForPoint(Pt3d pt, SetInt &a_poly) {
+void GmMultiPolyIntersectorImpl::GetPolysForPoint(Pt3d pt, SetInt& a_poly)
+{
   std::vector<ValueBox> result;
   m_rtree->query(bgi::intersects(pt), std::back_inserter(result));
 
   // Find the polygon that the point is inside
-  for (size_t i = 0; i < result.size(); ++i) {
-    GmBstPoly3d &poly = GetBoostPoly(result[i].second);
+  for (size_t i = 0; i < result.size(); ++i)
+  {
+    GmBstPoly3d& poly = GetBoostPoly(result[i].second);
     //(bg::within(pt, poly)) { // Seems to return true if inside
     bool rv = false;
-    switch (m_query) {
+    switch (m_query)
+    {
     case GMMPIQ_COVEREDBY:
       rv = bg::covered_by(pt, poly); // Seems to return true if inside or on
       break;
@@ -326,7 +371,8 @@ void GmMultiPolyIntersectorImpl::GetPolysForPoint(Pt3d pt, SetInt &a_poly) {
       XM_ASSERT(false);
       break;
     }
-    if (rv) {
+    if (rv)
+    {
       a_poly.insert(result[i].second + 1);
     }
   }
@@ -335,7 +381,8 @@ void GmMultiPolyIntersectorImpl::GetPolysForPoint(Pt3d pt, SetInt &a_poly) {
 //------------------------------------------------------------------------------
 /// \brief Go through results (potential polygons) and intersect each one.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::IntersectEachPolyWithLine() {
+void GmMultiPolyIntersectorImpl::IntersectEachPolyWithLine()
+{
   // Get potential polygons which intersect the line from the rtree
   std::vector<ValueBox> result;
   m_rtree->query(bgi::intersects(m_line), std::back_inserter(result));
@@ -346,13 +393,15 @@ void GmMultiPolyIntersectorImpl::IntersectEachPolyWithLine() {
   // compile
 
   // Go through the potential polygons and try to intersect them
-  for (size_t i = 0; i < result.size(); ++i) {
-    GmBstPoly3d &poly = GetBoostPoly(result[i].second);
+  for (size_t i = 0; i < result.size(); ++i)
+  {
+    GmBstPoly3d& poly = GetBoostPoly(result[i].second);
     std::deque<Pt3d> output;
     bg::intersection(poly, m_line, output);
     if (2 > output.size())
       PointsOnSegment(poly, m_line, output);
-    for (size_t j = 0; j < output.size(); ++j) {
+    for (size_t j = 0; j < output.size(); ++j)
+    {
       ix ixn(output[j], result[i].second + 1, XM_NODATA);
       m_d.m_ixs.push_back(ixn);
     }
@@ -365,17 +414,19 @@ void GmMultiPolyIntersectorImpl::IntersectEachPolyWithLine() {
 /// \param a_line: GmBstLine3d.
 /// \param a_output: Output.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::PointsOnSegment(const GmBstPoly3d &a_poly,
-                                                 const GmBstLine3d &a_line,
-                                                 std::deque<Pt3d> &a_output) {
+void GmMultiPolyIntersectorImpl::PointsOnSegment(const GmBstPoly3d& a_poly,
+                                                 const GmBstLine3d& a_line,
+                                                 std::deque<Pt3d>& a_output)
+{
   double tol = m_buffer * 1e-6;
-  for (size_t i = 0; i < a_poly.outer().size(); ++i) {
-    const Pt3d &p = a_poly.outer()[i];
-    if (gmOnLineAndBetweenEndpointsWithTol(
-            a_line[0], a_line[1], p.x, p.y,
-            tol)) { // don't add the point if it is already in the output
+  for (size_t i = 0; i < a_poly.outer().size(); ++i)
+  {
+    const Pt3d& p = a_poly.outer()[i];
+    if (gmOnLineAndBetweenEndpointsWithTol(a_line[0], a_line[1], p.x, p.y, tol))
+    { // don't add the point if it is already in the output
       bool dup = false;
-      for (size_t j = 0; j < a_output.size(); ++j) {
+      for (size_t j = 0; j < a_output.size(); ++j)
+      {
         if (gmEqualPointsXY(a_output[j], p, tol))
           dup = true;
       }
@@ -390,7 +441,8 @@ void GmMultiPolyIntersectorImpl::PointsOnSegment(const GmBstPoly3d &a_poly,
 /// t values are the percent (0.0 - 1.0) distance from the line segment start
 /// to each intersection.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::ComputeTValues() {
+void GmMultiPolyIntersectorImpl::ComputeTValues()
+{
   for (size_t i = 0; i < m_d.m_ixs.size(); ++i)
   {
     if (m_d.m_ixs[i].m_t == XM_NODATA)
@@ -403,31 +455,35 @@ void GmMultiPolyIntersectorImpl::ComputeTValues() {
   // get rid of any points that have a t value outside of the 0.0 to 1.0 range
   // the boost intersection can find phantom intersections just beyond the segment
   m_d.m_ixs.erase(std::remove_if(m_d.m_ixs.begin(), m_d.m_ixs.end(),
-    [](const ix & a_ix) { return a_ix.m_t < -gmXyTol() || a_ix.m_t > 1.0 + gmXyTol(); }),
-    m_d.m_ixs.end());
+                                 [](const ix& a_ix) {
+                                   return a_ix.m_t < -gmXyTol() || a_ix.m_t > 1.0 + gmXyTol();
+                                 }),
+                  m_d.m_ixs.end());
 } // GmMultiPolyIntersectorImpl::ComputeTValues
 //------------------------------------------------------------------------------
 /// \brief Does a preliminary sort of the intersections by t value.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::SortIntersections() {
+void GmMultiPolyIntersectorImpl::SortIntersections()
+{
   XM_ENSURE_TRUE_VOID_NO_ASSERT(m_d.m_ixs.size() > 1);
 
   // Sort intersections by t value
   std::sort(m_d.m_ixs.begin(), m_d.m_ixs.end(),
-            [](const ix &a, const ix &b) -> bool { return a.m_t < b.m_t; });
+            [](const ix& a, const ix& b) -> bool { return a.m_t < b.m_t; });
 
 } // GmMultiPolyIntersectorImpl::SortIntersections
 //------------------------------------------------------------------------------
 /// \brief Because unfortunately intersecting the line with the poly doesn't
 ///        always create an intersection if a point is on the polygon edge.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::EnsureEndPointsRepresented() {
+void GmMultiPolyIntersectorImpl::EnsureEndPointsRepresented()
+{
   // If 1st point was in or on poly, make sure there's an intersection for it
-  for (SetInt::iterator it = m_d.m_polys1.begin(); it != m_d.m_polys1.end();
-       ++it) {
+  for (SetInt::iterator it = m_d.m_polys1.begin(); it != m_d.m_polys1.end(); ++it)
+  {
     bool found = false;
-    for (size_t i = 0;
-         i < m_d.m_ixs.size() && !found && m_d.m_ixs[i].m_t == 0.0; ++i) {
+    for (size_t i = 0; i < m_d.m_ixs.size() && !found && m_d.m_ixs[i].m_t == 0.0; ++i)
+    {
       if (m_d.m_ixs[i].m_i == *it)
         found = true;
     }
@@ -436,11 +492,11 @@ void GmMultiPolyIntersectorImpl::EnsureEndPointsRepresented() {
   }
 
   // If 2nd point was in or on poly, make sure there's an intersection for it
-  for (SetInt::iterator it = m_d.m_polys2.begin(); it != m_d.m_polys2.end();
-       ++it) {
+  for (SetInt::iterator it = m_d.m_polys2.begin(); it != m_d.m_polys2.end(); ++it)
+  {
     bool found = false;
-    for (size_t i = m_d.m_ixs.size();
-         i-- > 0 && !found && m_d.m_ixs[i].m_t == 1.0;) {
+    for (size_t i = m_d.m_ixs.size(); i-- > 0 && !found && m_d.m_ixs[i].m_t == 1.0;)
+    {
       if (m_d.m_ixs[i].m_i == *it)
         found = true;
     }
@@ -453,11 +509,15 @@ void GmMultiPolyIntersectorImpl::EnsureEndPointsRepresented() {
 ///        that here.
 /// \param polyIds: 1-based list of polygons intersected by line segment.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::OffsetPolyIds(VecInt &polyIds) const {
-  if (m_startingId != 1) {
+void GmMultiPolyIntersectorImpl::OffsetPolyIds(VecInt& polyIds) const
+{
+  if (m_startingId != 1)
+  {
     int offset = m_startingId - 1;
-    for (int i = 0; i < (int)polyIds.size() - 1; ++i) {
-      if (polyIds[i] != XM_NONE) {
+    for (int i = 0; i < (int)polyIds.size() - 1; ++i)
+    {
+      if (polyIds[i] != XM_NONE)
+      {
         polyIds[i] += offset;
       }
     }
@@ -469,9 +529,9 @@ void GmMultiPolyIntersectorImpl::OffsetPolyIds(VecInt &polyIds) const {
 /// \param a_y1: y coordinate of 1st point defining a line segment.
 /// \param a_x2: x coordinate of 2nd point defining a line segment.
 /// \param a_y2: y coordinate of 2nd point defining a line segment.
-/// \param a_polyids: list of polygons intersected by line segment. Can be zero
+/// \param a_polyIds: list of polygons intersected by line segment. Can be zero
 ///                  or 1 based depending on a_startingId passed to constructor.
-/// \param a_tvalues: Values from 0.0 to 1.0 representing where on the line
+/// \param a_tValues: Values from 0.0 to 1.0 representing where on the line
 ///                  segment the intersection with the polygon in polyids
 ///                  occurs. If there are any t values there are always at
 ///                  least 2 and all represent where the line enters the
@@ -480,12 +540,15 @@ void GmMultiPolyIntersectorImpl::OffsetPolyIds(VecInt &polyIds) const {
 ///                  but we make the sizes equal by always making the last
 ///                  poly id -1.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
-                                                     double a_x2, double a_y2,
-                                                     VecInt &a_polyids,
-                                                     VecDbl &a_tvalues) {
+void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1,
+                                                     double a_y1,
+                                                     double a_x2,
+                                                     double a_y2,
+                                                     VecInt& a_polyIds,
+                                                     VecDbl& a_tValues)
+{
   VecPt3d pts;
-  TraverseLineSegment(a_x1, a_y1, a_x2, a_y2, a_polyids, a_tvalues, pts);
+  TraverseLineSegment(a_x1, a_y1, a_x2, a_y2, a_polyIds, a_tValues, pts);
 } // GmMultiPolyIntersectorImpl::TraverseLineSegment
 //------------------------------------------------------------------------------
 /// \brief Intersect segment with polys and save intersected polys.
@@ -493,15 +556,18 @@ void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
 /// \param a_y1: y coordinate of 1st point defining a line segment.
 /// \param a_x2: x coordinate of 2nd point defining a line segment.
 /// \param a_y2: y coordinate of 2nd point defining a line segment.
-/// \param a_polyids: list of polygons intersected by line segment. Can be zero
+/// \param a_polyIds: list of polygons intersected by line segment. Can be zero
 ///                  or 1 based depending on a_startingId passed to constructor.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
-                                                     double a_x2, double a_y2,
-                                                     VecInt &a_polyids) {
+void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1,
+                                                     double a_y1,
+                                                     double a_x2,
+                                                     double a_y2,
+                                                     VecInt& a_polyIds)
+{
   VecDbl tvalues;
   VecPt3d pts;
-  TraverseLineSegment(a_x1, a_y1, a_x2, a_y2, a_polyids, tvalues, pts);
+  TraverseLineSegment(a_x1, a_y1, a_x2, a_y2, a_polyIds, tvalues, pts);
 } // GmMultiPolyIntersectorImpl::TraverseLineSegment
 //-----------------------------------------------------------------------------
 /// \brief Intersect segment with polys and save intersected polys and
@@ -510,16 +576,19 @@ void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
 /// \param a_y1: y coordinate of 1st point defining a line segment.
 /// \param a_x2: x coordinate of 2nd point defining a line segment.
 /// \param a_y2: y coordinate of 2nd point defining a line segment.
-/// \param a_polyids: list of polygons intersected by line segment. Can be zero
+/// \param a_polyIds: list of polygons intersected by line segment. Can be zero
 ///                  or 1 based depending on a_startingId passed to constructor.
 /// \param a_pts: Intersection points.
 //-----------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
-                                                     double a_x2, double a_y2,
-                                                     VecInt &a_polyids,
-                                                     std::vector<Pt3d> &a_pts) {
+void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1,
+                                                     double a_y1,
+                                                     double a_x2,
+                                                     double a_y2,
+                                                     VecInt& a_polyIds,
+                                                     VecPt3d& a_pts)
+{
   VecDbl tvalues;
-  TraverseLineSegment(a_x1, a_y1, a_x2, a_y2, a_polyids, tvalues, a_pts);
+  TraverseLineSegment(a_x1, a_y1, a_x2, a_y2, a_polyIds, tvalues, a_pts);
 } // GmMultiPolyIntersectorImpl::TraverseLineSegment
 //-----------------------------------------------------------------------------
 /// \brief Intersect segment with polys and save intersected polys, t-values,
@@ -528,9 +597,9 @@ void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
 /// \param a_y1: y coordinate of 1st point defining a line segment.
 /// \param a_x2: x coordinate of 2nd point defining a line segment.
 /// \param a_y2: y coordinate of 2nd point defining a line segment.
-/// \param a_polyids: list of polygons intersected by line segment. Can be zero
+/// \param a_polyIds: list of polygons intersected by line segment. Can be zero
 ///                  or 1 based depending on a_startingId passed to constructor.
-/// \param a_tvalues: Values from 0.0 to 1.0 representing where on the line
+/// \param a_tValues: Values from 0.0 to 1.0 representing where on the line
 ///                  segment the intersection with the polygon in polyids
 ///                  occurs. If there are any t values there are always at
 ///                  least 2 and all represent where the line enters the
@@ -540,9 +609,14 @@ void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1, double a_y1,
 ///                  poly id -1.
 /// \param a_pts: Intersection points.
 //-----------------------------------------------------------------------------
-void GmMultiPolyIntersectorImpl::TraverseLineSegment(
-    double a_x1, double a_y1, double a_x2, double a_y2, VecInt &a_polyids,
-    VecDbl &a_tvalues, std::vector<Pt3d> &a_pts) {
+void GmMultiPolyIntersectorImpl::TraverseLineSegment(double a_x1,
+                                                     double a_y1,
+                                                     double a_x2,
+                                                     double a_y2,
+                                                     VecInt& a_polyIds,
+                                                     VecDbl& a_tValues,
+                                                     VecPt3d& a_pts)
+{
   m_pt1.Set(a_x1, a_y1, 0.0);
   m_pt2.Set(a_x2, a_y2, 0.0);
   GetPolysForPoint(m_pt1, m_d.m_polys1);
@@ -552,29 +626,78 @@ void GmMultiPolyIntersectorImpl::TraverseLineSegment(
   ComputeTValues();
   SortIntersections();
   EnsureEndPointsRepresented();
-  if (!m_sorter) {
+  if (!m_sorter)
+  {
     XM_ASSERT(false);
-  } else {
-    double kTol = 1e-13; // Used to compare t values which are always 0.0 - 1.0
-    m_sorter->Sort(m_d, a_polyids, a_tvalues, a_pts, kTol);
   }
-  OffsetPolyIds(a_polyids);
+  else
+  {
+    double kTol = 1e-13; // Used to compare t values which are always 0.0 - 1.0
+    m_sorter->Sort(m_d, a_polyIds, a_tValues, a_pts, kTol);
+  }
+  OffsetPolyIds(a_polyIds);
+  RemoveDuplicateTValues(a_polyIds, a_tValues, a_pts);
 
   m_d.m_ixs.clear();
   m_d.m_polys1.clear();
   m_d.m_polys2.clear();
   m_line.clear();
-} // GmMultiPolyIntersectorImpl::TraverseLineSegmentAll
+} // GmMultiPolyIntersectorImpl::TraverseLineSegment
+//-----------------------------------------------------------------------------
+/// \brief Removes duplicate T Values and updates the polygon ID and point vectors
+/// \param a_polyIds: list of polygons intersected by line segment. Can be zero
+///                  or 1 based depending on a_startingId passed to constructor.
+/// \param a_tValues: Values from 0.0 to 1.0 representing where on the line
+///                  segment the intersection with the polygon in polyids
+///                  occurs. If there are any t values there are always at
+///                  least 2 and all represent where the line enters the
+///                  polygon, except the last which represents where it exited.
+///                  There would therefore be one more t value than poly id
+///                  but we make the sizes equal by always making the last
+///                  poly id -1.
+/// \param a_pts: Intersection points.
+//-----------------------------------------------------------------------------
+void GmMultiPolyIntersectorImpl::RemoveDuplicateTValues(VecInt& a_polyIds,
+                                                        VecDbl& a_tValues,
+                                                        VecPt3d& a_pts)
+{
+  VecInt indexesToRemove;
+  int size((int)a_tValues.size());
+  for (int i = size - 1; i > 0; --i)
+  {
+    if (GTEQ_TOL(a_tValues[i], 1.0, XM_ZERO_TOL) && GTEQ_TOL(a_tValues[i - 1], 1.0, XM_ZERO_TOL))
+    {
+      for (int j = i - 1; j > 0; --j)
+      {
+        if (GTEQ_TOL(a_tValues[i], 1.0, XM_ZERO_TOL) && GTEQ_TOL(a_tValues[j], 1.0, XM_ZERO_TOL) &&
+            a_polyIds[i] == a_polyIds[j])
+          indexesToRemove.push_back(j);
+      }
+    }
+    else
+      break;
+  }
+  auto it = std::unique(indexesToRemove.begin(), indexesToRemove.end());
+  indexesToRemove.resize(std::distance(indexesToRemove.begin(), it));
+  for (auto&& i : indexesToRemove)
+  {
+    a_polyIds.erase(a_polyIds.begin() + i);
+    a_tValues.erase(a_tValues.begin() + i);
+    a_pts.erase(a_pts.begin() + i);
+  }
+} // GmMultiPolyIntersectorImpl::RemoveDuplicateTValues
 //-----------------------------------------------------------------------------
 /// \brief Finds the polygon containing the point
 /// \param a_pt: the location of the point
 /// \return the polygon id
 //-----------------------------------------------------------------------------
-int GmMultiPolyIntersectorImpl::PolygonFromPoint(const Pt3d &a_pt) {
+int GmMultiPolyIntersectorImpl::PolygonFromPoint(const Pt3d& a_pt)
+{
   int rval(XM_NONE);
   SetInt polys;
   GetPolysForPoint(a_pt, polys);
-  if (!polys.empty()) {
+  if (!polys.empty())
+  {
     rval = (int)*polys.begin();
   }
   return rval;
@@ -602,15 +725,19 @@ namespace // unnamed namespace
 //------------------------------------------------------------------------------
 /// \brief
 //------------------------------------------------------------------------------
-void iRunTest(double x1, double y1, double x2, double y2, const VecPt3d &pts,
-              const VecInt2d &polys, const VecInt &a_expectedPolyIDs,
-              const VecDbl &a_expectedtValues,
-              const VecPt3d &a_expectedPoints) {
+void iRunTest(double x1,
+              double y1,
+              double x2,
+              double y2,
+              const VecPt3d& pts,
+              const VecInt2d& polys,
+              const VecInt& a_expectedPolyIDs,
+              const VecDbl& a_expectedtValues,
+              const VecPt3d& a_expectedPoints)
+{
   BSHP<GmMultiPolyIntersectionSorter> sorter =
-      BSHP<GmMultiPolyIntersectionSorter>(
-          new GmMultiPolyIntersectionSorterTerse());
-  BSHP<GmMultiPolyIntersector> mpi =
-      GmMultiPolyIntersector::New(pts, polys, sorter);
+    BSHP<GmMultiPolyIntersectionSorter>(new GmMultiPolyIntersectionSorterTerse());
+  BSHP<GmMultiPolyIntersector> mpi = GmMultiPolyIntersector::New(pts, polys, sorter);
   VecInt polyIds1, polyIds2, polyIds3, polyIds4;
   VecDbl tValues1, tValues2;
   VecPt3d points1, points2;
@@ -656,14 +783,14 @@ void iRunTest(double x1, double y1, double x2, double y2, const VecPt3d &pts,
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OutOut() {
+void GmMultiPolyIntersectorUnitTests::test1OutOut()
+{
   VecPt3d pts = {{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys = {{0, 1, 2, 3}};
   VecInt expectedIds = {1, -1};
   VecDbl expectedTvals = {0.0833333, 0.916667};
   VecPt3d expectedPoints = {{0.0, 5.0, 0.0}, {10.0, 5.0, 0.0}};
-  iRunTest(-1, 5, 11, 5, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(-1, 5, 11, 5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1OutOut
 //------------------------------------------------------------------------------
@@ -680,7 +807,8 @@ void GmMultiPolyIntersectorUnitTests::test1OutOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OutIn() {
+void GmMultiPolyIntersectorUnitTests::test1OutIn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -703,7 +831,8 @@ void GmMultiPolyIntersectorUnitTests::test1OutIn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1InOut() {
+void GmMultiPolyIntersectorUnitTests::test1InOut()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys = {{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -726,7 +855,8 @@ void GmMultiPolyIntersectorUnitTests::test1InOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1InIn() {
+void GmMultiPolyIntersectorUnitTests::test1InIn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -749,7 +879,8 @@ void GmMultiPolyIntersectorUnitTests::test1InIn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OnOn() {
+void GmMultiPolyIntersectorUnitTests::test1OnOn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -772,7 +903,8 @@ void GmMultiPolyIntersectorUnitTests::test1OnOn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OnIn() {
+void GmMultiPolyIntersectorUnitTests::test1OnIn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -795,7 +927,8 @@ void GmMultiPolyIntersectorUnitTests::test1OnIn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1InOn() {
+void GmMultiPolyIntersectorUnitTests::test1InOn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -818,7 +951,8 @@ void GmMultiPolyIntersectorUnitTests::test1InOn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OutOn() {
+void GmMultiPolyIntersectorUnitTests::test1OutOn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -841,14 +975,14 @@ void GmMultiPolyIntersectorUnitTests::test1OutOn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OnOut() {
+void GmMultiPolyIntersectorUnitTests::test1OnOut()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.0, 0.0};
   VecPt3d expectedPoints = {{10.0, 5.0, 0.0}, {10.0, 5.0, 0.0}};
-  iRunTest(10, 5, 11, 5, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(10, 5, 11, 5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1OnOut
 //------------------------------------------------------------------------------
@@ -865,14 +999,14 @@ void GmMultiPolyIntersectorUnitTests::test1OnOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1EdgeInIn() {
+void GmMultiPolyIntersectorUnitTests::test1EdgeInIn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{3.0, 10.0, 0.0}, {7.0, 10.0, 0.0}};
-  iRunTest(3, 10, 7, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(3, 10, 7, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1EdgeInIn
 //------------------------------------------------------------------------------
@@ -889,14 +1023,14 @@ void GmMultiPolyIntersectorUnitTests::test1EdgeInIn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1EdgePtPt() {
+void GmMultiPolyIntersectorUnitTests::test1EdgePtPt()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{0.0, 10.0, 0.0}, {10.0, 10.0, 0.0}};
-  iRunTest(0, 10, 10, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(0, 10, 10, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1EdgePtPt
 //------------------------------------------------------------------------------
@@ -913,7 +1047,8 @@ void GmMultiPolyIntersectorUnitTests::test1EdgePtPt() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1EdgeOutOut() {
+void GmMultiPolyIntersectorUnitTests::test1EdgeOutOut()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -921,8 +1056,7 @@ void GmMultiPolyIntersectorUnitTests::test1EdgeOutOut() {
   VecPt3d expectedPoints = {{10.0, 10.0, 0.0}, {0.0, 10.0, 0.0}};
   // iRunTest(-1, 10, 11, 10, pts, polys, expectedIds, expectedTvals,
   // expectedPoints); // doesn't work
-  iRunTest(11, 10, -1, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(11, 10, -1, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1EdgeOutOut
 //------------------------------------------------------------------------------
@@ -939,25 +1073,23 @@ void GmMultiPolyIntersectorUnitTests::test1EdgeOutOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1EdgeOutIn() {
+void GmMultiPolyIntersectorUnitTests::test1EdgeOutIn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.166667, 1.0};
   VecPt3d expectedPoints = {{0.0, 10.0, 0.0}, {5.0, 10.0, 0.0}};
-  iRunTest(-1, 10, 5, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(-1, 10, 5, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
   expectedTvals = {0.0, 5 / 6.0};
   expectedPoints = {{5.0, 10.0, 0.0}, {0.0, 10.0, 0.0}};
-  iRunTest(5, 10, -1, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(5, 10, -1, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
   // iRunTest(-1, 0, 5, 0, pts, polys, expectedIds, expectedTvals,
   // expectedPoints); //works iRunTest(-1, 9.999999999999999, 5, 10, pts, polys,
   // expectedIds, expectedTvals, expectedPoints); //works
   expectedTvals = {1.0 / 3.0, 1.0};
   expectedPoints = {{10.0, 10.0, 0.0}, {0.0, 10.0, 0.0}};
-  iRunTest(15, 10, 0, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(15, 10, 0, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::test1EdgeOutIn
 //------------------------------------------------------------------------------
 /// \brief
@@ -973,7 +1105,8 @@ void GmMultiPolyIntersectorUnitTests::test1EdgeOutIn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1EdgeInOut() {
+void GmMultiPolyIntersectorUnitTests::test1EdgeInOut()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
@@ -999,14 +1132,14 @@ void GmMultiPolyIntersectorUnitTests::test1EdgeInOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OutPt() {
+void GmMultiPolyIntersectorUnitTests::test1OutPt()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{1.0, 1.0};
   VecPt3d expectedPoints = {{0.0, 10.0, 0.0}, {0.0, 10.0, 0.0}};
-  iRunTest(-1, 10, 0, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(-1, 10, 0, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1OutPt
 //------------------------------------------------------------------------------
@@ -1024,14 +1157,14 @@ void GmMultiPolyIntersectorUnitTests::test1OutPt() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1OutPtOut() {
+void GmMultiPolyIntersectorUnitTests::test1OutPtOut()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.5, 0.5};
   VecPt3d expectedPoints = {{0.0, 10.0, 0.0}, {0.0, 10.0, 0.0}};
-  iRunTest(-1, 9, 1, 11, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(-1, 9, 1, 11, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1OutPtOut
 //------------------------------------------------------------------------------
@@ -1049,14 +1182,14 @@ void GmMultiPolyIntersectorUnitTests::test1OutPtOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1AllOut() {
+void GmMultiPolyIntersectorUnitTests::test1AllOut()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds;
   VecDbl expectedTvals;
   VecPt3d expectedPoints = {};
-  iRunTest(-1, 10, 0, 11, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(-1, 10, 0, 11, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1AllOut
 //------------------------------------------------------------------------------
@@ -1073,14 +1206,14 @@ void GmMultiPolyIntersectorUnitTests::test1AllOut() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1PtIn() {
+void GmMultiPolyIntersectorUnitTests::test1PtIn()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{0.0, 10.0, 0.0}, {5.0, 10.0, 0.0}};
-  iRunTest(0, 10, 5, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(0, 10, 5, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1PtIn
 //------------------------------------------------------------------------------
@@ -1097,14 +1230,14 @@ void GmMultiPolyIntersectorUnitTests::test1PtIn() {
 // (0,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test1InPt() {
+void GmMultiPolyIntersectorUnitTests::test1InPt()
+{
   VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}};
   VecInt2d polys{{0, 1, 2, 3}};
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{5.0, 10.0, 0.0}, {10.0, 10.0, 0.0}};
-  iRunTest(5, 10, 10, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(5, 10, 10, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test1InPt
 //------------------------------------------------------------------------------
@@ -1121,9 +1254,9 @@ void GmMultiPolyIntersectorUnitTests::test1InPt() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2OnOn() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2OnOn()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys{{0, 1, 4, 3}};
   VecInt expectedIds{1, -1}; // old: (1)
   VecDbl expectedTvals{0.0, 1.0};
@@ -1145,9 +1278,9 @@ void GmMultiPolyIntersectorUnitTests::test2OnOn() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2InOn() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2InOn()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys{{0, 1, 4, 3}};
   VecInt expectedIds{1, -1}; // old: (1)
   VecDbl expectedTvals{0.0, 1.0};
@@ -1169,9 +1302,9 @@ void GmMultiPolyIntersectorUnitTests::test2InOn() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2OnIn() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2OnIn()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{1, -1}; // old: (1)
   VecDbl expectedTvals{0.0, 1.0};
@@ -1193,16 +1326,14 @@ void GmMultiPolyIntersectorUnitTests::test2OnIn() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2OutOut() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2OutOut()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{1, 2, -1}; // old: (1)(2)
   VecDbl expectedTvals{0.0454545, 0.5, 0.954545};
-  VecPt3d expectedPoints = {
-      {0.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {20.0, 5.0, 0.0}};
-  iRunTest(-1, 5, 21, 5, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecPt3d expectedPoints = {{0.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {20.0, 5.0, 0.0}};
+  iRunTest(-1, 5, 21, 5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test2OutOut
 //------------------------------------------------------------------------------
@@ -1219,16 +1350,14 @@ void GmMultiPolyIntersectorUnitTests::test2OutOut() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2OutIn() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2OutIn()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{{0, 1, 4, 3}}, {1, 2, 5, 4}};
   VecInt expectedIds{1, 2, -1}; // old: (1)(2)
   VecDbl expectedTvals{0.0625, 0.6875, 1.0};
-  VecPt3d expectedPoints = {
-      {0.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {15.0, 5.0, 0.0}};
-  iRunTest(-1, 5, 15, 5, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecPt3d expectedPoints = {{0.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {15.0, 5.0, 0.0}};
+  iRunTest(-1, 5, 15, 5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test2OutIn
 //------------------------------------------------------------------------------
@@ -1245,14 +1374,13 @@ void GmMultiPolyIntersectorUnitTests::test2OutIn() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2InOut() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2InOut()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{1, 2, -1}; // old: (1)(2)
   VecDbl expectedTvals{0.0, 0.3125, 0.9375};
-  VecPt3d expectedPoints = {
-      {5.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {20.0, 5.0, 0.0}};
+  VecPt3d expectedPoints = {{5.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {20.0, 5.0, 0.0}};
   iRunTest(5, 5, 21, 5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::test2InOut
@@ -1270,14 +1398,13 @@ void GmMultiPolyIntersectorUnitTests::test2InOut() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2InIn() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2InIn()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{1, 2, -1}; // old: (1)(2)
   VecDbl expectedTvals{0.0, 0.5, 1.0};
-  VecPt3d expectedPoints = {
-      {5.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {15.0, 5.0, 0.0}};
+  VecPt3d expectedPoints = {{5.0, 5.0, 0.0}, {10.0, 5.0, 0.0}, {15.0, 5.0, 0.0}};
   iRunTest(5, 5, 15, 5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::test2InIn
 //------------------------------------------------------------------------------
@@ -1294,15 +1421,14 @@ void GmMultiPolyIntersectorUnitTests::test2InIn() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2InPt() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2InPt()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{1, -1}; // old: (1)(2)
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{5.0, 10.0, 0.0}, {10.0, 10.0, 0.0}};
-  iRunTest(5, 10, 10, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(5, 10, 10, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::test2InPt
 //------------------------------------------------------------------------------
 /// \brief
@@ -1318,15 +1444,14 @@ void GmMultiPolyIntersectorUnitTests::test2InPt() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2PtIn() {
-  VecPt3d pts{{0, 0, 0},  {10, 0, 0},  {20, 0, 0},
-              {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
+void GmMultiPolyIntersectorUnitTests::test2PtIn()
+{
+  VecPt3d pts{{0, 0, 0}, {10, 0, 0}, {20, 0, 0}, {0, 10, 0}, {10, 10, 0}, {20, 10, 0}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{2, -1}; // old: (1)(2)
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{10.0, 10.0, 0.0}, {15.0, 10.0, 0.0}};
-  iRunTest(10, 10, 15, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(10, 10, 15, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::test2PtIn
 //------------------------------------------------------------------------------
 /// \brief
@@ -1342,27 +1467,93 @@ void GmMultiPolyIntersectorUnitTests::test2PtIn() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2InEdgePt() {
+void GmMultiPolyIntersectorUnitTests::test2InEdgePt()
+{
   // The comment below is not true. Check
   // GmMultiPolyIntersectorImpl::GmMultiPolyIntersectorImpl to see that we don't
   // set z's to 0.0 and this test works. We are using Pt3d as a 2D boost
   // geometry so z's don't come into play.
   //  // The non-equal z values would cause this test to fail but now we
   //  // set them all to 0.0.
-  VecPt3d pts{{0, 0, 100},  {10, 0, 110},  {20, 0, 105},
-              {0, 10, 104}, {10, 10, 103}, {20, 10, 106}};
+  VecPt3d pts{{0, 0, 100}, {10, 0, 110}, {20, 0, 105}, {0, 10, 104}, {10, 10, 103}, {20, 10, 106}};
   VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
   VecInt expectedIds{1, 2, -1};
   VecDbl expectedTvals = {0.0, 1 / 3.0, 1};
-  VecPt3d expectedPoints = {
-      {5.0, 10.0, 0.0}, {10.0, 10.0, 0.0}, {20.0, 10.0, 0.0}};
-  iRunTest(5, 10, 20, 10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecPt3d expectedPoints = {{5.0, 10.0, 0.0}, {10.0, 10.0, 0.0}, {20.0, 10.0, 0.0}};
+  iRunTest(5, 10, 20, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
   expectedIds = {2, 1, -1};
   expectedPoints = {{15.0, 10.0, 0.0}, {10.0, 10.0, 0.0}, {0.0, 10.0, 0.0}};
-  iRunTest(15, 10, 0, 10, pts, polys, expectedIds, expectedTvals,
+  iRunTest(15, 10, 0, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
+} // GmMultiPolyIntersectorUnitTests::test2InEdgePt
+//------------------------------------------------------------------------------
+/// \brief
+/// \verbatim
+//  (0,10)
+//    3-------------4-------------5
+//    |             |             |
+//    |             |             |
+//    |     1|1     |      2      |
+//    |             |             |
+//    |             |             |
+//    0------------2|1------------2
+// (0,0)                        (20,0)
+/// \endverbatim
+//------------------------------------------------------------------------------
+void GmMultiPolyIntersectorUnitTests::testCorners()
+{
+  VecPt3d pts{{0, 0, 100}, {10, 0, 110}, {20, 0, 105}, {0, 10, 104}, {10, 10, 103}, {20, 10, 106}};
+  VecInt2d polys = {{0, 1, 4, 3}, {1, 2, 5, 4}};
+  VecInt expectedIds{1, -1};
+  VecDbl expectedTvals = {0.0, 1};
+  VecPt3d expectedPoints = {{5.0, 5.0, 0.0}, {10.0, 0.0, 0.0}};
+  iRunTest(5, 5, 10, 0, pts, polys, expectedIds, expectedTvals, expectedPoints);
+  expectedIds = {2, -1};
+  expectedPoints = {{15.0, 5.0, 0.0}, {10.0, 10.0, 0.0}};
+  iRunTest(15, 5, 10, 10, pts, polys, expectedIds, expectedTvals, expectedPoints);
+} // GmMultiPolyIntersectorUnitTests::testCorners
+//------------------------------------------------------------------------------
+/// \brief
+/// \verbatim
+//  Pt 0: (104.346,-300.604,48.558)
+//  Pt 1: (105.148,-298.88,48.225)
+//  Pt 2: (105.994,-297.142,47.225)
+//  Pt 3: (110.439,-299.669,48.533)
+//  Pt 4: (109.543,-301.391,47.2)
+//  Pt 5: (108.738,-303.082,47.867)
+//  Pt 6: (113.06,-305.811,47.175)
+//  Pt 7: (113.886,-304.089,48.175)
+//    2-------------3
+//    |             | \
+//    |             |    \
+//    |      2      |      \
+//    |             |    3   \
+//    |             |           \
+//    1-------------4-------------7
+//    |             |             |
+//    |             |             |
+//    |      1      |      4      |
+//    |             |             |
+//    |             |             |
+//    0-------------5-------------6
+// (0,0)                        (20,0)
+/// \endverbatim
+//------------------------------------------------------------------------------
+void GmMultiPolyIntersectorUnitTests::testQuadCorners()
+{
+  VecPt3d pts{{104.346, -300.604, 48.558}, {105.148, -298.88, 48.225}, {105.994, -297.142, 47.225},
+              {110.439, -299.669, 48.533}, {109.543, -301.391, 47.2},  {108.738, -303.082, 47.867},
+              {113.06, -305.811, 47.175},  {113.886, -304.089, 48.175}};
+  VecInt2d polys = {{0, 5, 4, 1}, {1, 4, 3, 2}, {4, 7, 3}, {5, 6, 7, 4}};
+  VecInt expectedIds{2, -1};
+  VecDbl expectedTvals = {0.0, 1};
+  VecPt3d expectedPoints = {{107.769, -299.267, 0.0}, {109.543, -301.391, 0.0}};
+  iRunTest(107.769, -299.267, 109.543, -301.391, pts, polys, expectedIds, expectedTvals,
            expectedPoints);
-} // GmMultiPolyIntersectorUnitTests::test2PtIn
+  expectedIds = {4, -1};
+  expectedPoints = {{109.543, -301.391, 0.0}, {111.302, -303.601, 0.0}};
+  iRunTest(109.543, -301.391, 111.302, -303.601, pts, polys, expectedIds, expectedTvals,
+           expectedPoints);
+} // GmMultiPolyIntersectorUnitTests::testQuadCorners
 //------------------------------------------------------------------------------
 /// \brief
 /// \verbatim
@@ -1383,16 +1574,16 @@ void GmMultiPolyIntersectorUnitTests::test2InEdgePt() {
 // (0,0)                        (20,0)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::test2InOutIn() {
+void GmMultiPolyIntersectorUnitTests::test2InOutIn()
+{
   VecPt3d pts{{0, 10, 0}, {10, 10, 0}, {10, 20, 0}, {0, 20, 0},
               {10, 0, 0}, {20, 0, 0},  {20, 10, 0}};
   VecInt2d polys = {{0, 1, 2, 3}, {4, 5, 6, 1}};
   VecInt expectedIds = {1, -1, 2, -1}; // old: (1)(2)
   VecDbl expectedTvals = {0.0, 0.2, 0.8, 1.0};
   VecPt3d expectedPoints = {
-      {8.0, 18.0, 0.0}, {10.0, 16.0, 0.0}, {16.0, 10.0, 0.0}, {18.0, 8.0, 0.0}};
-  iRunTest(8, 18, 18, 8, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+    {8.0, 18.0, 0.0}, {10.0, 16.0, 0.0}, {16.0, 10.0, 0.0}, {18.0, 8.0, 0.0}};
+  iRunTest(8, 18, 18, 8, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::test2InOutIn
 //------------------------------------------------------------------------------
 /// \brief Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1412,7 +1603,8 @@ void GmMultiPolyIntersectorUnitTests::test2InOutIn() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testInsideToInside() {
+void GmMultiPolyIntersectorUnitTests::testInsideToInside()
+{
   VecPt3d pts;
   VecInt2d polys;
   trBuildGridTrianglePolys(1, 2, pts, polys);
@@ -1424,8 +1616,7 @@ void GmMultiPolyIntersectorUnitTests::testInsideToInside() {
                             {10.0, -5.0, 0.0},
                             {13.333333333333, -6.666666666667, 0.0},
                             {15.0, -7.5, 0.0}};
-  iRunTest(5, -2.5, 15, -7.5, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(5, -2.5, 15, -7.5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testInsideToInside
 //------------------------------------------------------------------------------
 /// \brief Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1445,21 +1636,19 @@ void GmMultiPolyIntersectorUnitTests::testInsideToInside() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testOutsideToOutside() {
+void GmMultiPolyIntersectorUnitTests::testOutsideToOutside()
+{
   VecPt3d pts;
   VecInt2d polys;
   trBuildGridTrianglePolys(1, 2, pts, polys);
 
   VecInt expectedIds{1, 4, 3, 5, 6, 7, -1};
-  VecDbl expectedTvals{0.0454545, 0.0833333, 0.34375, 0.5,
-                       0.65625,   0.916667,  0.954545};
-  VecPt3d expectedPoints = {
-      {0.0, -0.454545454545, 0.0}, {0.8333333333333, -0.833333333333, 0.0},
-      {6.5625, -3.4375, 0.0},      {10.0, -5.0, 0.0},
-      {13.4375, -6.5625, 0.0},     {19.166666666667, -9.166666666667, 0.0},
-      {20.0, -9.545454545455, 0.0}};
-  iRunTest(-1, 0, 21, -10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecDbl expectedTvals{0.0454545, 0.0833333, 0.34375, 0.5, 0.65625, 0.916667, 0.954545};
+  VecPt3d expectedPoints = {{0.0, -0.454545454545, 0.0}, {0.8333333333333, -0.833333333333, 0.0},
+                            {6.5625, -3.4375, 0.0},      {10.0, -5.0, 0.0},
+                            {13.4375, -6.5625, 0.0},     {19.166666666667, -9.166666666667, 0.0},
+                            {20.0, -9.545454545455, 0.0}};
+  iRunTest(-1, 0, 21, -10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testOutsideToOutside
 //------------------------------------------------------------------------------
 /// \brief Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1480,7 +1669,8 @@ void GmMultiPolyIntersectorUnitTests::testOutsideToOutside() {
 //                             (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testTouchesVertex() {
+void GmMultiPolyIntersectorUnitTests::testTouchesVertex()
+{
   VecPt3d pts;
   VecInt2d polys;
   trBuildGridTrianglePolys(1, 2, pts, polys);
@@ -1488,8 +1678,7 @@ void GmMultiPolyIntersectorUnitTests::testTouchesVertex() {
   VecInt expectedIds;
   VecDbl expectedTvals;
   VecPt3d expectedPoints = {};
-  iRunTest(1, 1, -1, -1, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(1, 1, -1, -1, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testTouchesVertex
 //------------------------------------------------------------------------------
 /// \brief  Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1509,7 +1698,8 @@ void GmMultiPolyIntersectorUnitTests::testTouchesVertex() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testTouchesEdge() {
+void GmMultiPolyIntersectorUnitTests::testTouchesEdge()
+{
 #ifdef __linux__
   TS_SKIP("GREENBUILD: This test does not pass on Linux builds.");
 #endif
@@ -1519,8 +1709,7 @@ void GmMultiPolyIntersectorUnitTests::testTouchesEdge() {
   VecInt expectedIds{1, -1};
   VecDbl expectedTvals{1.0, 1.0};
   VecPt3d expectedPoints = {{0.0, -2.0, 0.0}, {0.0, -2.0, 0.0}};
-  iRunTest(-1, -1, 0, -2, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(-1, -1, 0, -2, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testTouchesEdge
 //------------------------------------------------------------------------------
 /// \brief Given 3 x 3 2D grid turned into triangles with point at poly center
@@ -1556,7 +1745,8 @@ void GmMultiPolyIntersectorUnitTests::testTouchesEdge() {
 //                                          (30, -30)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testAlongEdgesInsideToInside() {
+void GmMultiPolyIntersectorUnitTests::testAlongEdgesInsideToInside()
+{
   // TS_FAIL("GmMultiPolyIntersectorUnitTests::testAlongEdgesInsideToInside");
 
   VecPt3d pts;
@@ -1573,8 +1763,7 @@ void GmMultiPolyIntersectorUnitTests::testAlongEdgesInsideToInside() {
                             {15.0, -15.0, 0.0},
                             {20.0, -20.0, 0.0},
                             {24.0, -24.0, 0.0}};
-  iRunTest(6, -6, 24, -24, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(6, -6, 24, -24, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::testAlongEdgesInsideToInside
 //------------------------------------------------------------------------------
@@ -1603,7 +1792,8 @@ void GmMultiPolyIntersectorUnitTests::testAlongEdgesInsideToInside() {
 //                                          (30, -20)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testAlongEdgesOutsideToOutside() {
+void GmMultiPolyIntersectorUnitTests::testAlongEdgesOutsideToOutside()
+{
   VecPt3d pts;
   VecInt2d polys;
   trBuildGridTrianglePolys(2, 3, pts, polys);
@@ -1611,14 +1801,11 @@ void GmMultiPolyIntersectorUnitTests::testAlongEdgesOutsideToOutside() {
   // VecInt expectedIds = {16,20,24,23,-1}; SurfaceIter results
   // MfMapLayerUGridImp::TraverseLineSegment results:
   VecInt expectedIds{16, 20, 24, -1};
-  VecDbl expectedTvals{0.016129032258064516, 0.33870967741935482,
-                       0.66129032258064513, 0.98387096774193550};
-  VecPt3d expectedPoints = {{0.0, -10.0, 0.0},
-                            {10.0, -10.0, 0.0},
-                            {20.0, -10.0, 0.0},
-                            {30.0, -10.0, 0.0}};
-  iRunTest(-0.5, -10, 30.5, -10, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecDbl expectedTvals{0.016129032258064516, 0.33870967741935482, 0.66129032258064513,
+                       0.98387096774193550};
+  VecPt3d expectedPoints = {
+    {0.0, -10.0, 0.0}, {10.0, -10.0, 0.0}, {20.0, -10.0, 0.0}, {30.0, -10.0, 0.0}};
+  iRunTest(-0.5, -10, 30.5, -10, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testAlongEdgesOutsideToOutside
 //------------------------------------------------------------------------------
 /// \brief Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1638,7 +1825,8 @@ void GmMultiPolyIntersectorUnitTests::testAlongEdgesOutsideToOutside() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testEdgeThroughOppositeVertexAtAngle() {
+void GmMultiPolyIntersectorUnitTests::testEdgeThroughOppositeVertexAtAngle()
+{
   // TS_FAIL("GmMultiPolyIntersectorUnitTests::testEdgeThroughOppositeVertexAtAngle");
 
   VecPt3d pts;
@@ -1654,8 +1842,7 @@ void GmMultiPolyIntersectorUnitTests::testEdgeThroughOppositeVertexAtAngle() {
                             {10.0, -3.214285714286, 0.0},
                             {15.0, -5.0, 0.0},
                             {20.0, -6.785714285714, 0.0}};
-  iRunTest(8, -2.5, 22, -7.5, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(8, -2.5, 22, -7.5, pts, polys, expectedIds, expectedTvals, expectedPoints);
 
 } // GmMultiPolyIntersectorUnitTests::testEdgeThroughOppositeVertexAtAngle
 //------------------------------------------------------------------------------
@@ -1676,7 +1863,8 @@ void GmMultiPolyIntersectorUnitTests::testEdgeThroughOppositeVertexAtAngle() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testStartAtEdgeThroughAdjacent() {
+void GmMultiPolyIntersectorUnitTests::testStartAtEdgeThroughAdjacent()
+{
   // TS_FAIL("GmMultiPolyIntersectorUnitTests::testStartAtEdgeThroughAdjacent");
 
   VecPt3d pts;
@@ -1688,10 +1876,8 @@ void GmMultiPolyIntersectorUnitTests::testStartAtEdgeThroughAdjacent() {
   // VecDbl expectedTvals = {0.0,0.4,0.8};
   VecInt expectedIds{5, 8, -1};
   VecDbl expectedTvals{0.0, 0.4, 0.8};
-  VecPt3d expectedPoints = {
-      {10.0, -8.0, 0.0}, {14.0, -4.0, 0.0}, {18.0, 0.0, 0.0}};
-  iRunTest(10, -8, 20, 2, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecPt3d expectedPoints = {{10.0, -8.0, 0.0}, {14.0, -4.0, 0.0}, {18.0, 0.0, 0.0}};
+  iRunTest(10, -8, 20, 2, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testStartAtEdgeThroughAdjacent
 //------------------------------------------------------------------------------
 /// \brief Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1713,7 +1899,8 @@ void GmMultiPolyIntersectorUnitTests::testStartAtEdgeThroughAdjacent() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testInsideToEdgeThenThroughAdjacent() {
+void GmMultiPolyIntersectorUnitTests::testInsideToEdgeThenThroughAdjacent()
+{
 // TS_FAIL("GmMultiPolyIntersectorUnitTests::testInsideToEdgeThenThroughAdjacent");
 #ifdef __linux__
   TS_SKIP("GREENBUILD: This test does not pass on Linux builds.");
@@ -1728,23 +1915,19 @@ void GmMultiPolyIntersectorUnitTests::testInsideToEdgeThenThroughAdjacent() {
   VecInt expectedIds{3, -1};
   VecDbl expectedTvals{0.0, 1.0};
   VecPt3d expectedPoints = {{9.0, -5.0, 0.0}, {10.0, -8.0, 0.0}};
-  iRunTest(9, -5, 10, -8, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(9, -5, 10, -8, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testInsideToEdgeThenThroughAdjacent
 //------------------------------------------------------------------------------
 /// \brief We only do the first part: inside to edge.
 /// \verbatim
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testMap2MfBug() {
-  VecPt3d pts{{1937.0003414079, 11829.937474193, 0.0},
-              {1947.0331979019, 11744.658193995, 0.0},
-              {1806.3085553039, 11640.957366058, 0.0},
-              {1827.8055464927, 11817.091027732, 0.0},
-              {2046.1951363232, 11842.783920654, 0.0},
-              {2155.4908205085, 11854.643944679, 0.0},
-              {2160.8354359402, 11805.390806652, 0.0},
-              {2070.1604445251, 11710.224742147, 0.0}};
+void GmMultiPolyIntersectorUnitTests::testMap2MfBug()
+{
+  VecPt3d pts{{1937.0003414079, 11829.937474193, 0.0}, {1947.0331979019, 11744.658193995, 0.0},
+              {1806.3085553039, 11640.957366058, 0.0}, {1827.8055464927, 11817.091027732, 0.0},
+              {2046.1951363232, 11842.783920654, 0.0}, {2155.4908205085, 11854.643944679, 0.0},
+              {2160.8354359402, 11805.390806652, 0.0}, {2070.1604445251, 11710.224742147, 0.0}};
   VecInt2d polys(2);
   polys[0] = {0, 3, 2, 1};
   polys[1] = {0, 1, 7, 6, 5, 4};
@@ -1752,22 +1935,18 @@ void GmMultiPolyIntersectorUnitTests::testMap2MfBug() {
   const double t = 0.41350462827872492;
   VecInt expectedIds{2, 1, -1};
   VecDbl expectedTvals{0.0, .5, 1.0};
-  VecPt3d expectedPoints = {
-      {2046.1951363232, 11842.783920654, 0.00000000000000000},
-      {1937.0003414079, 11829.937474193, 0.00000000000000000},
-      {1827.8055464927, 11817.091027732, 0.00000000000000000}};
-  iRunTest(2046.1951363232, 11842.783920654, 1827.8055464927,
-           11817.091027732, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
-  expectedIds = {1, 2, -1, -1};
-  expectedTvals = {0.0, .5, 1, 1};
+  VecPt3d expectedPoints = {{2046.1951363232, 11842.783920654, 0.00000000000000000},
+                            {1937.0003414079, 11829.937474193, 0.00000000000000000},
+                            {1827.8055464927, 11817.091027732, 0.00000000000000000}};
+  iRunTest(2046.1951363232, 11842.783920654, 1827.8055464927, 11817.091027732, pts, polys,
+           expectedIds, expectedTvals, expectedPoints);
+  expectedIds = {1, 2, -1};
+  expectedTvals = {0.0, .5, 1};
   expectedPoints = {{1827.8055464927, 11817.091027732, 0.0},
                     {1937.0003414079, 11829.937474193, 0.0},
-                    {2046.1951363232, 11842.783920654, 0.0},
                     {2046.1951363232, 11842.783920654, 0.0}};
-  iRunTest(1827.8055464927, 11817.091027732, 2046.1951363232,
-           11842.783920654, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(1827.8055464927, 11817.091027732, 2046.1951363232, 11842.783920654, pts, polys,
+           expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testInsideToEdgeThenThroughAdjacent
 //------------------------------------------------------------------------------
 /// \brief Given 1 x 2 2D grid turned into triangles with point at poly center
@@ -1787,7 +1966,8 @@ void GmMultiPolyIntersectorUnitTests::testMap2MfBug() {
 //                            (20, -10)
 /// \endverbatim
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testEndAtEdgeFromAdjacent() {
+void GmMultiPolyIntersectorUnitTests::testEndAtEdgeFromAdjacent()
+{
   // TS_FAIL("GmMultiPolyIntersectorUnitTests::testEndAtEdgeFromAdjacent");
 
   VecPt3d pts;
@@ -1800,23 +1980,19 @@ void GmMultiPolyIntersectorUnitTests::testEndAtEdgeFromAdjacent() {
   VecInt expectedIds{8, 5, -1};
   VecDbl expectedTvals{0.2, 0.6, 1.0};
   VecPt3d expectedPoints = {{18.0, 0.0}, {14.0, -4.0, 0.0}, {10.0, -8.0, 0.0}};
-  iRunTest(20, 2, 10, -8, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(20, 2, 10, -8, pts, polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testEndAtEdgeFromAdjacent
 //------------------------------------------------------------------------------
 /// \brief This case revealed the need for a tolerance when comparing t values.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersectorUnitTests::testSmsCase1() {
-  VecPt3d pts{{-39.719999999999999, 90.079999999999998, 0.0},
-              {-21.129999999999999, 90.469999999999999, 1.0},
-              {-38.930000000000000, 75.840000000000003, 2.0},
-              {-20.539999999999999, 76.629999999999995, 3.0},
-              {-39.719999999999999, 62.000000000000000, 4.0},
-              {-20.539999999999999, 61.609999999999999, 5.0},
-              {-40.509999999999998, 47.770000000000003, 6.0},
-              {-20.150000000000002, 46.579999999999998, 7.0},
-              {-41.100000000000001, 30.370000000000001, 8.0},
-              {-19.550000000000001, 29.379999999999999, 9.0}};
+void GmMultiPolyIntersectorUnitTests::testSmsCase1()
+{
+  VecPt3d pts{
+    {-39.719999999999999, 90.079999999999998, 0.0}, {-21.129999999999999, 90.469999999999999, 1.0},
+    {-38.930000000000000, 75.840000000000003, 2.0}, {-20.539999999999999, 76.629999999999995, 3.0},
+    {-39.719999999999999, 62.000000000000000, 4.0}, {-20.539999999999999, 61.609999999999999, 5.0},
+    {-40.509999999999998, 47.770000000000003, 6.0}, {-20.150000000000002, 46.579999999999998, 7.0},
+    {-41.100000000000001, 30.370000000000001, 8.0}, {-19.550000000000001, 29.379999999999999, 9.0}};
   VecInt2d polys(8);
   polys[0] = {7, 5, 6};
   polys[1] = {3, 2, 5};
@@ -1828,22 +2004,17 @@ void GmMultiPolyIntersectorUnitTests::testSmsCase1() {
   polys[7] = {4, 6, 5};
 
   VecInt expectedIds{6, 3, 2, 7, 8, 1, 5, 4, -1};
-  VecDbl expectedTvals{
-      0.065777232109665892, 0.18968813237387866, 0.26837085508795250,
-      0.35199491192297022,  0.47395399691316503, 0.58799734941084614,
-      0.68358069055240822,  0.81969307266961533, 0.93250275302111885};
-  VecPt3d expectedPoints = {{-31.97119143306, 90.242562417488, 0.0},
-                            {-31.8980840019, 81.619602868102, 0.0},
-                            {-31.8516611955, 76.144072194429, 0.0},
-                            {-31.80232300197, 70.32467407928, 0.0},
-                            {-31.73036714182, 61.837541354813, 0.0},
-                            {-31.66308156385, 53.901264454499, 0.0},
-                            {-31.60668739257, 47.249619744458, 0.0},
-                            {-31.52638108712, 37.777559072921, 0.0},
-                            {-31.45982337572, 29.92713341726, 0.0}};
-  iRunTest(-32.009999999999998, 94.819999999999993, -31.420000000000002,
-           25.230000000000000, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  VecDbl expectedTvals{0.065777232109665892, 0.18968813237387866, 0.26837085508795250,
+                       0.35199491192297022,  0.47395399691316503, 0.58799734941084614,
+                       0.68358069055240822,  0.81969307266961533, 0.93250275302111885};
+  VecPt3d expectedPoints = {
+    {-31.97119143306, 90.242562417488, 0.0}, {-31.8980840019, 81.619602868102, 0.0},
+    {-31.8516611955, 76.144072194429, 0.0},  {-31.80232300197, 70.32467407928, 0.0},
+    {-31.73036714182, 61.837541354813, 0.0}, {-31.66308156385, 53.901264454499, 0.0},
+    {-31.60668739257, 47.249619744458, 0.0}, {-31.52638108712, 37.777559072921, 0.0},
+    {-31.45982337572, 29.92713341726, 0.0}};
+  iRunTest(-32.009999999999998, 94.819999999999993, -31.420000000000002, 25.230000000000000, pts,
+           polys, expectedIds, expectedTvals, expectedPoints);
 } // GmMultiPolyIntersectorUnitTests::testSmsCase1
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1853,7 +2024,8 @@ void GmMultiPolyIntersectorUnitTests::testSmsCase1() {
 //------------------------------------------------------------------------------
 /// \brief Test a large number of polygons for speed.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolys() {
+void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolys()
+{
 #ifndef _DEBUG
   // TS_FAIL("GmMultiPolyIntersectorUnitTests::testHuge");
 
@@ -1874,14 +2046,14 @@ void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolys() {
                             {15.0, -15.0, 0.0},
                             {20.0, -20.0, 0.0},
                             {24.0, -24.0, 0.0}};
-  iRunTest(6, -6, 24, -24, pts, polys, expectedIds, expectedTvals,
-           expectedPoints);
+  iRunTest(6, -6, 24, -24, pts, polys, expectedIds, expectedTvals, expectedPoints);
 #endif
 } // GmMultiPolyIntersector2IntermediateTests::testLargeNumPolys
 //------------------------------------------------------------------------------
 /// \brief This test can be used for speed comparisons.
 //------------------------------------------------------------------------------
-void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolysAndSegments() {
+void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolysAndSegments()
+{
 #ifndef _DEBUG
   // TS_FAIL("GmMultiPolyIntersectorUnitTests::testHuge");
 
@@ -1895,15 +2067,14 @@ void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolysAndSegments() {
   VecInt expectedIds = {2, 17, 18, 33, -1};
   VecDbl expectedTvals = {0.0, 0.22222, 0.5, 0.777778, 1.0};
   BSHP<GmMultiPolyIntersectionSorter> sorter =
-      BSHP<GmMultiPolyIntersectionSorter>(
-          new GmMultiPolyIntersectionSorterTerse());
-  BSHP<GmMultiPolyIntersector> mpi =
-      GmMultiPolyIntersector::New(pts, polys, sorter);
+    BSHP<GmMultiPolyIntersectionSorter>(new GmMultiPolyIntersectionSorterTerse());
+  BSHP<GmMultiPolyIntersector> mpi = GmMultiPolyIntersector::New(pts, polys, sorter);
   VecInt polyIds;
   VecDbl tValues;
   const int nIntersectingLines =
-      /*1e5*/ 1000; // Go big for serious timing testing
-  for (size_t i = 0; i < nIntersectingLines; ++i) {
+    /*1e5*/ 1000; // Go big for serious timing testing
+  for (size_t i = 0; i < nIntersectingLines; ++i)
+  {
     // 3 different segments repeated
     mpi->TraverseLineSegment(6, -6, 24, -24, polyIds, tValues);
     mpi->TraverseLineSegment(7, -6, 25, -24, polyIds, tValues);
@@ -1914,6 +2085,6 @@ void GmMultiPolyIntersector2IntermediateTests::testLargeNumPolysAndSegments() {
 #endif
 } // GmMultiPolyIntersector2IntermediateTests::testLargeNumPolysAndSegments
 
-  //} // namespace xms
+//} // namespace xms
 
 #endif

--- a/xmsgrid/geometry/GmMultiPolyIntersector.t.h
+++ b/xmsgrid/geometry/GmMultiPolyIntersector.t.h
@@ -61,6 +61,8 @@ public:
   void test2InPt();
   void test2PtIn();
   void test2InEdgePt();
+  void testCorners();
+  void testQuadCorners();
   void test2InOutIn();
 
   // Multiple polys

--- a/xmsgrid/geometry/GmMultiPolyIntersector.t.h
+++ b/xmsgrid/geometry/GmMultiPolyIntersector.t.h
@@ -63,6 +63,7 @@ public:
   void test2InEdgePt();
   void testCorners();
   void testQuadCorners();
+  void testQuadCornersBug12396();
   void test2InOutIn();
 
   // Multiple polys


### PR DESCRIPTION
Remove excess "end" (-1) polygon IDs for TraverseLineSegment and add test: GmMultiPolyIntersectorUnitTests::testQuadCornersBug12396