### PR TITLE
Use legacy wchar_t compiler flag for Windows MD builds

### DIFF
--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -41,7 +41,7 @@ jobs:
 # MAC
 # ----------------------------------------------------------------------------------------------
   mac:
-    name: Clang-11.0 (${{ matrix.build_type }}, Macos)
+    name: Clang-11.0 (${{ matrix.build_type }}, ${{ matrix.python-version }}, Macos)
     runs-on: ${{ matrix.platform }}
 
     strategy:
@@ -99,15 +99,15 @@ jobs:
         run: conan user
       - name: Set Conan Path
         run: |
-          echo ::set-env name=CONAN_PATH::$(conan config get storage.path)
+          echo "CONAN_PATH=$(conan config get storage.path)" >> $GITHUB_ENV
       # Get Tag Name (ONLY RUNS ON TAGS)
       - name: Get Tag
         id: gitTag
-        uses: olegtarasov/get-tag@v2
+        uses: little-core-labs/get-git-tag@v3.0.2
         if: startsWith(github.ref, 'refs/tags/')
       # Set Conan Version (ONLY RUNS ON TAGS)
       - name: Set Conan Version
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_REFERENCE: 'xmsgrid/${{ steps.gitTag.outputs.tag }}'
           XMS_VERSION: ${{ steps.gitTag.outputs.tag }}
@@ -117,9 +117,9 @@ jobs:
       # Check for release branch
       - name: Get Branch Name
         id: gitBranch
-        uses: nelonoel/branch-name@v1
+        uses: nelonoel/branch-name@v1.0.1
       - name: Change Channel and URL if Release Branch
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_CHANNEL: stable
           AQUAPI_URL: ${{ secrets.AQUAPI_URL_STABLE }}
@@ -159,7 +159,7 @@ jobs:
 # LINUX
 # ----------------------------------------------------------------------------------------------
   linux:
-    name: GCC-${{ matrix.compiler-version }} (${{ matrix.build_type }}, Linux)
+    name: GCC-${{ matrix.compiler-version }} (${{ matrix.build_type }}, ${{ matrix.python-version }}, Linux)
     runs-on: ${{ matrix.platform }}
 
     strategy:
@@ -218,20 +218,20 @@ jobs:
         run: conan user
       - name: Set Conan Path
         run: |
-          echo ::set-env name=CONAN_PATH::$(conan config get storage.path)
+          echo "CONAN_PATH=$(conan config get storage.path)" >> $GITHUB_ENV
           mkdir -p $(conan config get storage.path)
       - name: Set Conan Docker Options
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_DOCKER_RUN_OPTIONS: "-v '${{ env.CONAN_PATH }}:/home/conan/.conan/data'"
       # Get Tag Name
       - name: Get Tag
         id: gitTag
-        uses: olegtarasov/get-tag@v2
+        uses: little-core-labs/get-git-tag@v3.0.2
         if: startsWith(github.ref, 'refs/tags/')
       # Set Conan Version
       - name: Set Conan Version
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_REFERENCE: 'xmsgrid/${{ steps.gitTag.outputs.tag }}'
           XMS_VERSION: ${{ steps.gitTag.outputs.tag }}
@@ -241,9 +241,9 @@ jobs:
       # Check for release branch
       - name: Get Branch Name
         id: gitBranch
-        uses: nelonoel/branch-name@v1
+        uses: nelonoel/branch-name@v1.0.1
       - name: Change Channel and URL if Release Branch
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_CHANNEL: stable
           AQUAPI_URL: ${{ secrets.AQUAPI_URL_STABLE }}
@@ -285,7 +285,7 @@ jobs:
 # WINDOWS
 # ----------------------------------------------------------------------------------------------
   windows:
-    name: Visual Studio ${{ matrix.compiler-version }} (${{ matrix.build_type }}, Windows)
+    name: Visual Studio ${{ matrix.compiler-version }} (${{ matrix.build_type }}, ${{ matrix.python-version }}, Windows)
     runs-on: ${{ matrix.platform }}
 
     strategy:
@@ -335,7 +335,7 @@ jobs:
           pip install conan conan_package_tools devpi-client wheel
       # Setup Visual Studio
       - name: Setup Visual Studio
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
         with:
           vs-version: ${{ matrix.compiler-version }}
       # Setup Conan
@@ -344,16 +344,16 @@ jobs:
         shell: cmd
       - name: Set Conan Path
         run: |
-          echo "::set-env name=CONAN_PATH::$(conan config get storage.path)"
+          echo "CONAN_PATH=$(conan config get storage.path)" >> $env:GITHUB_ENV
         shell: powershell
       # Get Tag Name
       - name: Get Tag
         id: gitTag
-        uses: olegtarasov/get-tag@v2
+        uses: little-core-labs/get-git-tag@v3.0.2
         if: startsWith(github.ref, 'refs/tags/')
       # Set Conan Version
       - name: Set Conan Version
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_REFERENCE: 'xmsgrid/${{ steps.gitTag.outputs.tag }}'
           XMS_VERSION: ${{ steps.gitTag.outputs.tag }}
@@ -363,9 +363,9 @@ jobs:
       # Check for release branch
       - name: Get Branch Name
         id: gitBranch
-        uses: nelonoel/branch-name@v1
+        uses: nelonoel/branch-name@v1.0.1
       - name: Change Channel and URL if Release Branch
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CONAN_CHANNEL: stable
           AQUAPI_URL: ${{ secrets.AQUAPI_URL_STABLE }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,17 @@ set(XMS_VERSION "\"99.99.99\"" CACHE STRING "Library Version")
 add_definitions(-DXMS_VERSION=\"${XMS_VERSION}\")
 
 if(WIN32)
+    string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MT" USES_MT)
+    if(NOT USES_MT)
+        string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
+    endif()
+
+    if(NOT USES_MT)
+        add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
+    endif()
+
     if(XMS_BUILD)
         add_definitions(/D _WIN32_WINNT=0x0501)  # Windows XP and higher
-        add_definitions(/Zc:wchar_t-)  # Treat wchar_t as built-in type
     else(NOT XMS_BUILD)
         add_definitions(/D BOOST_ALL_NO_LIB)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,15 +29,7 @@ set(XMS_VERSION "\"99.99.99\"" CACHE STRING "Library Version")
 add_definitions(-DXMS_VERSION=\"${XMS_VERSION}\")
 
 if(WIN32)
-    string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MT" USES_MT)
-    if(NOT USES_MT)
-        string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
-    endif()
-
-    if(NOT USES_MT)
-        add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
-    endif()
-
+    add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
     if(XMS_BUILD)
         add_definitions(/D _WIN32_WINNT=0x0501)  # Windows XP and higher
     else(NOT XMS_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if(WIN32)
         string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
     endif()
 
+    message("CONAN_SETTINGS_COMPILER_RUNTIME: ${CONAN_SETTINGS_COMPILER_RUNTIME}")
+    message("USES_MT: ${USES_MT}")
+
     if(USES_MT)
         message("Treating wchar_t as a built-in type.")
         add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,17 @@ set(XMS_VERSION "\"99.99.99\"" CACHE STRING "Library Version")
 
 add_definitions(-DXMS_VERSION=\"${XMS_VERSION}\")
 
+if(IS_CONDA_BUILD)
+  include(${CMAKE_CURRENT_LIST_DIR}/condabuildinfo.cmake)
+else() # If we are not using conda, we are using conan
+  # Conan setup
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+  conan_basic_setup(TARGETS)
+  set(EXT_INCLUDE_DIRS ${CONAN_INCLUDE_DIRS})
+  set(EXT_LIB_DIRS ${CONAN_LIB_DIRS})
+  set(EXT_LIBS ${CONAN_LIBS})
+endif(IS_CONDA_BUILD)
+
 if(WIN32)
     string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MT" USES_MT)
     if(NOT USES_MT)
@@ -51,17 +62,6 @@ if(WIN32)
         add_definitions(/D BOOST_ALL_NO_LIB)
     endif()
 endif()
-
-if(IS_CONDA_BUILD)
-  include(${CMAKE_CURRENT_LIST_DIR}/condabuildinfo.cmake)
-else() # If we are not using conda, we are using conan
-  # Conan setup
-  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-  conan_basic_setup(TARGETS)
-  set(EXT_INCLUDE_DIRS ${CONAN_INCLUDE_DIRS})
-  set(EXT_LIB_DIRS ${CONAN_LIB_DIRS})
-  set(EXT_LIBS ${CONAN_LIBS})
-endif(IS_CONDA_BUILD)
 
 if(IS_PYTHON_BUILD)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,6 @@ if(WIN32)
         string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
     endif()
 
-    message("CONAN_SETTINGS_COMPILER_RUNTIME: ${CONAN_SETTINGS_COMPILER_RUNTIME}")
-    message("USES_MT: ${USES_MT}")
-
     if(USES_MT)
         message("Treating wchar_t as a built-in type.")
         add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,19 @@ set(XMS_VERSION "\"99.99.99\"" CACHE STRING "Library Version")
 add_definitions(-DXMS_VERSION=\"${XMS_VERSION}\")
 
 if(WIN32)
-    add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
+    string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MT" USES_MT)
+    if(NOT USES_MT)
+        string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
+    endif()
+
+    if(USES_MT)
+        message("Treating wchar_t as a built-in type.")
+        add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
+    else()
+        message("Treating wchar_t as a typedef.")
+        add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
+    endif()
+
     if(XMS_BUILD)
         add_definitions(/D _WIN32_WINNT=0x0501)  # Windows XP and higher
     else(NOT XMS_BUILD)

--- a/_package/setup.py
+++ b/_package/setup.py
@@ -11,7 +11,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 requires = [
     'numpy',
-    'xmscore>=4.0.0',
+    'xmscore>=4.0.1',
 ]
 
 version = __version__

--- a/_package/xms/grid/__init__.py
+++ b/_package/xms/grid/__init__.py
@@ -3,4 +3,4 @@ from . import geometry  # NOQA: F401
 from . import triangulate  # NOQA: F401
 from . import ugrid  # NOQA: F401
 
-__version__ = '5.0.0'
+__version__ = '5.0.4'

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,7 @@ class XmsgridConan(ConanFile):
         self.requires("boost/1.74.0@aquaveo/stable")
         if self.options.pybind:
             self.requires("pybind11/2.5.0@aquaveo/testing")
-        self.requires("xmscore/4.0.0@aquaveo/stable")
+        self.requires("xmscore/4.0.1@aquaveo/stable")
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -51,6 +51,9 @@ class XmsgridConan(ConanFile):
         if self.options.pybind:
             self.requires("pybind11/2.5.0@aquaveo/testing")
         self.requires("xmscore/4.0.1@aquaveo/stable")
+        if self.settings.os == 'Macos':
+            # Use conan-center-index syntax for Mac
+            self.requires('bzip2/1.0.8')
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class XmsgridConan(ConanFile):
 
     def requirements(self):
         """Requirements"""
-        if self.settings.compiler == 'Visual Studio':
+        if self.settings.compiler == 'Visual Studio' and 'MD' in str(self.settings.compiler.runtime):
             self.requires("boost/1.74.0@aquaveo/testing")  # Use legacy wchar_t setting for XMS.
         else:
             self.requires("boost/1.74.0@aquaveo/stable")

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class XmsgridConan(ConanFile):
 
     def requirements(self):
         """Requirements"""
-        if self.settings.compiler == 'Visual Studio' and 'MD' in str(self.settings.compiler.runtime):
+        if self.settings.compiler == 'Visual Studio':
             self.requires("boost/1.74.0@aquaveo/testing")  # Use legacy wchar_t setting for XMS.
         else:
             self.requires("boost/1.74.0@aquaveo/stable")

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,10 +47,13 @@ class XmsgridConan(ConanFile):
 
     def requirements(self):
         """Requirements"""
-        self.requires("boost/1.74.0@aquaveo/stable")
+        if self.settings.compiler == 'Visual Studio' and 'MD' in str(self.settings.compiler.runtime):
+            self.requires("boost/1.74.0@aquaveo/testing")  # Use legacy wchar_t setting for XMS.
+        else:
+            self.requires("boost/1.74.0@aquaveo/stable")
         if self.options.pybind:
             self.requires("pybind11/2.5.0@aquaveo/testing")
-        self.requires("xmscore/4.0.1@aquaveo/stable")
+        self.requires("xmscore/4.0.2@aquaveo/stable")
         if self.settings.os == 'Macos':
             # Use conan-center-index syntax for Mac
             self.requires('bzip2/1.0.8')


### PR DESCRIPTION
Prevents link errors when building with XMS. Updated boost and xmscore requirements. Merged CI fixes from xmscore.