### PR TITLE
Update Boost

### DIFF
--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -287,7 +287,7 @@ jobs:
 # WINDOWS
 # ----------------------------------------------------------------------------------------------
   windows:
-    name: Visual Studio ${{ matrix.compiler-version }} (${{ matrix.build_type }}, ${{ matrix.python-version }}, Windows)
+    name: Visual Studio ${{ matrix.compiler-version }} (${{ matrix.build_type }}, ${{ matrix.python-version }}, ${{ matrix.wchar_t }} wchar_t, Windows)
     runs-on: ${{ matrix.platform }}
 
     strategy:
@@ -297,8 +297,10 @@ jobs:
         python-version: [3.6.8]
         compiler-version: [16]
         build_type: [Release, Debug]
+        wchar_t: [builtin, typedef]
 
     env:
+      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}-${{ matrix.wchar_t }}
       # Library Variables
       LIBRARY_NAME: xmsgrid
       XMS_VERSION: 6.0.0
@@ -313,6 +315,7 @@ jobs:
       CONAN_REMOTES: https://conan.aquaveo.com
       CONAN_BUILD_TYPES: ${{ matrix.build_type }}
       CONAN_VISUAL_VERSIONS: ${{ matrix.compiler-version }}
+      CONAN_OPTIONS: xmsgrid:wchar_t=${{ matrix.wchar_t }}
       # Aquapi Variables
       AQUAPI_USERNAME: ${{ secrets.AQUAPI_USERNAME_SECRET }}
       AQUAPI_PASSWORD: ${{ secrets.AQUAPI_PASSWORD_SECRET }}
@@ -379,12 +382,12 @@ jobs:
       # Zip Packages
       - name: Zip Conan Packages
         run: |
-          tar czf ${{ github.workspace }}/${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz ${{ env.CONAN_PATH }}/${{ env.LIBRARY_NAME }}/${{ env.XMS_VERSION }}/aquaveo/${{ env.CONAN_CHANNEL}}/package
+          tar czf ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz ${{ env.CONAN_PATH }}/${{ env.LIBRARY_NAME }}/${{ env.XMS_VERSION }}/aquaveo/${{ env.CONAN_CHANNEL}}/package
       - name: Add Artifact
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
-          path: ${{ github.workspace }}/${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz
+          name: ${{ env.MATRIX_NAME }}
+          path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
       # Get the Release Data
       - name: Get Release
         id: git_release
@@ -399,7 +402,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AQUAVEO_GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.git_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz
-          asset_name: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz
+          asset_path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
+          asset_name: ${{ env.MATRIX_NAME }}.tar.gz
           asset_content_type: application/zip
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -299,7 +299,6 @@ jobs:
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
       # Library Variables
       LIBRARY_NAME: xmsgrid
       XMS_VERSION: 6.0.0
@@ -380,12 +379,12 @@ jobs:
       # Zip Packages
       - name: Zip Conan Packages
         run: |
-          tar czf ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz ${{ env.CONAN_PATH }}/${{ env.LIBRARY_NAME }}/${{ env.XMS_VERSION }}/aquaveo/${{ env.CONAN_CHANNEL}}/package
+          tar czf ${{ github.workspace }}/${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz ${{ env.CONAN_PATH }}/${{ env.LIBRARY_NAME }}/${{ env.XMS_VERSION }}/aquaveo/${{ env.CONAN_CHANNEL}}/package
       - name: Add Artifact
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ env.MATRIX_NAME }}
-          path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
+          name: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
+          path: ${{ github.workspace }}/${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz
       # Get the Release Data
       - name: Get Release
         id: git_release
@@ -400,7 +399,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AQUAVEO_GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.git_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
-          asset_name: ${{ env.MATRIX_NAME }}.tar.gz
+          asset_path: ${{ github.workspace }}/${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz
+          asset_name: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}.tar.gz
           asset_content_type: application/zip
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -1,4 +1,4 @@
-name: XmsGrid-5.0
+name: XmsGrid-6.0
 
 on: [push, pull_request]
 
@@ -54,9 +54,9 @@ jobs:
     env:
       # Library Variables
       LIBRARY_NAME: xmsgrid
-      XMS_VERSION: 5.0.0
+      XMS_VERSION: 6.0.0
       # Conan Variables
-      CONAN_REFERENCE: xmsgrid/5.0.0
+      CONAN_REFERENCE: xmsgrid/6.0.0
       CONAN_ARCHS: x86_64
       CONAN_USERNAME: aquaveo
       CONAN_CHANNEL: testing
@@ -173,9 +173,9 @@ jobs:
     env:
       # Library Variables
       LIBRARY_NAME: xmsgrid
-      XMS_VERSION: 5.0.0
+      XMS_VERSION: 6.0.0
       # Conan Variables
-      CONAN_REFERENCE: xmsgrid/5.0.0
+      CONAN_REFERENCE: xmsgrid/6.0.0
       CONAN_ARCHS: x86_64
       CONAN_USERNAME: aquaveo
       CONAN_CHANNEL: testing
@@ -301,9 +301,9 @@ jobs:
     env:
       # Library Variables
       LIBRARY_NAME: xmsgrid
-      XMS_VERSION: 5.0.0
+      XMS_VERSION: 6.0.0
       # Conan Variables
-      CONAN_REFERENCE: xmsgrid/5.0.0
+      CONAN_REFERENCE: xmsgrid/6.0.0
       CONAN_ARCHS: x86_64
       CONAN_USERNAME: aquaveo
       CONAN_CHANNEL: testing

--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -287,7 +287,7 @@ jobs:
 # WINDOWS
 # ----------------------------------------------------------------------------------------------
   windows:
-    name: Visual Studio ${{ matrix.compiler-version }} (${{ matrix.build_type }}, ${{ matrix.python-version }}, ${{ matrix.wchar_t }} wchar_t, Windows)
+    name: Visual Studio ${{ matrix.compiler-version }} (${{ matrix.build_type }}, ${{ matrix.python-version }}, Windows)
     runs-on: ${{ matrix.platform }}
 
     strategy:
@@ -297,10 +297,9 @@ jobs:
         python-version: [3.6.8]
         compiler-version: [16]
         build_type: [Release, Debug]
-        wchar_t: [builtin, typedef]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}-${{ matrix.wchar_t }}
+      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
       # Library Variables
       LIBRARY_NAME: xmsgrid
       XMS_VERSION: 6.0.0

--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -314,7 +314,6 @@ jobs:
       CONAN_REMOTES: https://conan.aquaveo.com
       CONAN_BUILD_TYPES: ${{ matrix.build_type }}
       CONAN_VISUAL_VERSIONS: ${{ matrix.compiler-version }}
-      CONAN_OPTIONS: xmsgrid:wchar_t=${{ matrix.wchar_t }}
       # Aquapi Variables
       AQUAPI_USERNAME: ${{ secrets.AQUAPI_USERNAME_SECRET }}
       AQUAPI_PASSWORD: ${{ secrets.AQUAPI_PASSWORD_SECRET }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,18 +41,14 @@ endif(IS_CONDA_BUILD)
 
 if(WIN32)
     if(USE_TYPEDEF_WCHAR_T)
-        message("Treating wchar_t as a built-in type.")
-        add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
-    else()
         message("Treating wchar_t as a typedef.")
-        add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
+        add_definitions(/Zc:wchar_t-)
+    else()
+        message("Treating wchar_t as a built-in type.")
+        add_definitions(/Zc:wchar_t)
     endif()
 
-    if(XMS_BUILD)
-        add_definitions(/D _WIN32_WINNT=0x0501)  # Windows XP and higher
-    else(NOT XMS_BUILD)
-        add_definitions(/D BOOST_ALL_NO_LIB)
-    endif()
+	add_definitions(/D BOOST_ALL_NO_LIB)
 endif()
 
 if(IS_PYTHON_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,7 @@ else() # If we are not using conda, we are using conan
 endif(IS_CONDA_BUILD)
 
 if(WIN32)
-    string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MT" USES_MT)
-    if(NOT USES_MT)
-        string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
-    endif()
-
-    if(USES_MT)
+    if(USE_TYPEDEF_WCHAR_T)
         message("Treating wchar_t as a built-in type.")
         add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
     else()

--- a/_package/xms/grid/__init__.py
+++ b/_package/xms/grid/__init__.py
@@ -3,4 +3,4 @@ from . import geometry  # NOQA: F401
 from . import triangulate  # NOQA: F401
 from . import ugrid  # NOQA: F401
 
-__version__ = '5.5.2'
+__version__ = '6.0.0'

--- a/build.py
+++ b/build.py
@@ -71,7 +71,13 @@ if __name__ == "__main__":
             wchar_options = dict(options)
             wchar_options.update({'xmsgrid:wchar_t': 'typedef'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
-        wchar_updated_builds.append([settings, options, env_vars, build_requires])
+        elif settings['compiler'] == 'Visual Studio':
+            wchar_options = dict(options)
+            wchar_options.update({'xmsgrid:wchar_t': 'builtin'})
+            wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
+        else:
+            wchar_updated_builds.append([settings, options, env_vars, build_requires])
+            
     builder.builds = wchar_updated_builds
 
     builder.run()

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     wchar_updated_builds = []
     for settings, options, env_vars, build_requires, reference in builder.items:
         # wchar_t option
-        if not settings['compiler'] == 'Visual Studio' and options.get('xmsgrid:pybind', False):
+        if settings['compiler'] == 'Visual Studio' and options.get('xmsgrid:pybind', False):
             wchar_options = dict(options)
             wchar_options.update({'xmsgrid:wchar_t': 'typedef'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     wchar_updated_builds = []
     for settings, options, env_vars, build_requires, reference in builder.items:
         # wchar_t option
-        if not settings.compiler == 'Visual Studio' and options.get('xmsgrid:pybind', False):
+        if not settings['compiler'] == 'Visual Studio' and options.get('xmsgrid:pybind', False):
             wchar_options = dict(options)
             wchar_options.update({'xmsgrid:wchar_t': 'typedef'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     wchar_updated_builds = []
     for settings, options, env_vars, build_requires, reference in builder.items:
         # wchar_t option
-        if settings['compiler'] == 'Visual Studio' and options.get('xmsgrid:pybind', False):
+        if settings['compiler'] == 'Visual Studio' and not options.get('xmsgrid:pybind', False):
             wchar_options = dict(options)
             wchar_options.update({'xmsgrid:wchar_t': 'typedef'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])

--- a/build.py
+++ b/build.py
@@ -57,11 +57,21 @@ if __name__ == "__main__":
     testing_updated_builds = []
     for settings, options, env_vars, build_requires, reference in builder.items:
         # testing option
-        if not options.get('xmsgrid:xms', False) and not options.get('xmsgrid:pybind', False):
+        if not options.get('xmsgrid:pybind', False):
             testing_options = dict(options)
             testing_options.update({'xmsgrid:testing': True})
             testing_updated_builds.append([settings, testing_options, env_vars, build_requires])
         testing_updated_builds.append([settings, options, env_vars, build_requires])
     builder.builds = testing_updated_builds
+    
+    wchar_updated_builds = []
+    for settings, options. env_vars, build_requires, reference in builder.items:
+        # wchar_t option
+        if not options.get('xmsgrid:pybind', False):
+            wchar_options = dict(options)
+            wchar_options.update({'xmsgrid:wchar_t': 'typedef'})
+            wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
+        wchar_updated_builds.append([settings, options, env_vars, build_requires])
+    builder.builds = wchar_updated_builds
 
     builder.run()

--- a/build.py
+++ b/build.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     builder.builds = testing_updated_builds
     
     wchar_updated_builds = []
-    for settings, options. env_vars, build_requires, reference in builder.items:
+    for settings, options, env_vars, build_requires, reference in builder.items:
         # wchar_t option
         if not options.get('xmsgrid:pybind', False):
             wchar_options = dict(options)

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     wchar_updated_builds = []
     for settings, options, env_vars, build_requires, reference in builder.items:
         # wchar_t option
-        if not options.get('xmsgrid:pybind', False):
+        if not settings.compiler == 'Visual Studio' and options.get('xmsgrid:pybind', False):
             wchar_options = dict(options)
             wchar_options.update({'xmsgrid:wchar_t': 'typedef'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])

--- a/conanfile.py
+++ b/conanfile.py
@@ -51,7 +51,7 @@ class XmsgridConan(ConanFile):
         if self.options.wchar_t == 'typedef':
             if self.settings.compiler != 'Visual Studio':
                 raise ConanException("wchar_t=typedef only supported in Visual Studio")
-            if self.settings.pybind:
+            if self.options.pybind:
                 raise ConanException("wchar_t=typedef not supported with pybind=True")
 
         self.options['xmscore'].wchar_t = self.options.wchar_t

--- a/conanfile.py
+++ b/conanfile.py
@@ -62,7 +62,7 @@ class XmsgridConan(ConanFile):
         self.requires("boost/1.74.0.3@aquaveo/stable")
         if self.options.pybind:
             self.requires("pybind11/2.5.0@aquaveo/testing")
-        self.requires("xmscore/4.0.2@aquaveo/stable")
+        self.requires("xmscore/5.0.1@aquaveo/stable")
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,8 +50,10 @@ class XmsgridConan(ConanFile):
 
         self.options['xmscore'].pybind = self.options.pybind
         self.options['xmscore'].testing = self.options.testing
-        self.options['xmscore'].wchar_t = self.options.wchar_t
-        self.options['boost'].wchar_t = self.options.wchar_t
+        
+        if s_compiler == 'Visual Studio':
+            self.options['xmscore'].wchar_t = self.options.wchar_t
+            self.options['boost'].wchar_t = self.options.wchar_t
 
     def config_options(self):
         if self.settings.compiler != 'Visual Studio':

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,11 +15,14 @@ class XmsgridConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "wchar_t": ['builtin', 'typedef'],
-        "xms": [True, False],
         "pybind": [True, False],
         "testing": [True, False],
     }
-    default_options = "xms=False", "pybind=False", "testing=False"
+    default_options = {
+        "wchar_t": False,
+        "pybind": False,
+        "testing": False,
+    }
     generators = "cmake"
     build_requires = "cxxtest/4.4@aquaveo/stable"
     exports = "CMakeLists.txt", "LICENSE", "test_files/*"
@@ -34,7 +37,6 @@ class XmsgridConan(ConanFile):
         s_compiler = self.settings.compiler
         s_compiler_version = self.settings.compiler.version
 
-        self.options['xmscore'].xms = self.options.xms
         self.options['xmscore'].pybind = self.options.pybind
         self.options['xmscore'].testing = self.options.testing
 
@@ -64,9 +66,6 @@ class XmsgridConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-
-        if self.settings.compiler == 'Visual Studio':
-            cmake.definitions["XMS_BUILD"] = self.options.xms
 
         # CXXTest doesn't play nice with PyBind. Also, it would be nice to not
         # have tests in release code. Thus, if we want to run tests, we will

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,7 +45,7 @@ class XmsgridConan(ConanFile):
                 and float(s_compiler_version.value) < 9.0:
             raise ConanException("Clang > 9.0 is required for Mac.")
         
-        if self.options.wchar_t == 'typedef' and self.options.pybind:
+        if if s_compiler == 'Visual Studio' and self.options.wchar_t == 'typedef' and self.options.pybind:
             raise ConanException("wchar_t=typedef not supported with pybind=True")
 
         self.options['xmscore'].pybind = self.options.pybind

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,7 +45,7 @@ class XmsgridConan(ConanFile):
                 and float(s_compiler_version.value) < 9.0:
             raise ConanException("Clang > 9.0 is required for Mac.")
         
-        if if s_compiler == 'Visual Studio' and self.options.wchar_t == 'typedef' and self.options.pybind:
+        if s_compiler == 'Visual Studio' and self.options.wchar_t == 'typedef' and self.options.pybind:
             raise ConanException("wchar_t=typedef not supported with pybind=True")
 
         self.options['xmscore'].pybind = self.options.pybind

--- a/conanfile.py
+++ b/conanfile.py
@@ -78,7 +78,8 @@ class XmsgridConan(ConanFile):
         cmake.definitions["BUILD_TESTING"] = self.options.testing
         cmake.definitions["XMSGRID_TEST_PATH"] = "test_files"
         cmake.definitions["PYTHON_TARGET_VERSION"] = self.env.get("PYTHON_TARGET_VERSION", "3.6")
-        cmake.definitions["USE_TYPEDEF_WCHAR_T"] = (self.options.wchar_t == 'typedef')
+        if self.settings.compiler == 'Visual Studio':
+            cmake.definitions["USE_TYPEDEF_WCHAR_T"] = (self.options.wchar_t == 'typedef')
         cmake.configure(source_folder=".")
         cmake.build()
         cmake.install()

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,9 +37,6 @@ class XmsgridConan(ConanFile):
         s_compiler = self.settings.compiler
         s_compiler_version = self.settings.compiler.version
 
-        self.options['xmscore'].pybind = self.options.pybind
-        self.options['xmscore'].testing = self.options.testing
-
         if s_compiler == "apple-clang" and s_os == 'Linux':
             raise ConanException("Clang on Linux is not supported.")
 
@@ -54,6 +51,8 @@ class XmsgridConan(ConanFile):
             if self.options.pybind:
                 raise ConanException("wchar_t=typedef not supported with pybind=True")
 
+        self.options['xmscore'].pybind = self.options.pybind
+        self.options['xmscore'].testing = self.options.testing
         self.options['xmscore'].wchar_t = self.options.wchar_t
         self.options['boost'].wchar_t = self.options.wchar_t
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,16 +45,17 @@ class XmsgridConan(ConanFile):
                 and float(s_compiler_version.value) < 9.0:
             raise ConanException("Clang > 9.0 is required for Mac.")
         
-        if self.options.wchar_t == 'typedef':
-            if self.settings.compiler != 'Visual Studio':
-                raise ConanException("wchar_t=typedef only supported in Visual Studio")
-            if self.options.pybind:
-                raise ConanException("wchar_t=typedef not supported with pybind=True")
+        if self.options.wchar_t == 'typedef' and self.options.pybind:
+            raise ConanException("wchar_t=typedef not supported with pybind=True")
 
         self.options['xmscore'].pybind = self.options.pybind
         self.options['xmscore'].testing = self.options.testing
         self.options['xmscore'].wchar_t = self.options.wchar_t
         self.options['boost'].wchar_t = self.options.wchar_t
+
+    def config_options(self):
+        if self.settings.compiler != 'Visual Studio':
+            del self.options.wchar_t
 
     def requirements(self):
         """Requirements"""

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class XmsgridConan(ConanFile):
         "testing": [True, False],
     }
     default_options = {
-        "wchar_t": False,
+        "wchar_t": 'builtin',
         "pybind": False,
         "testing": False,
     }


### PR DESCRIPTION
- Removed the `xms` option from `conanfile.py` since we never used it.
- Added `wchar_t` option to `conanfile.py` to control Visual Studio's `/Zc:wchar_t` flag.
- Switch to Aquaveo Boost package.
- Update to `xmscore` 5.0.1.