### PR TITLE
-fix quadrant search for 2D. Set the z value of the point to 0.0 for …

### DIFF
--- a/xmsgrid/geometry/GmPtSearch.cpp
+++ b/xmsgrid/geometry/GmPtSearch.cpp
@@ -441,6 +441,9 @@ void GmPtSearchImpl::NearestPtsToPt(const Pt3d& a_pt,
   }
   else
   {
+    if (m_2dSearch)
+      tmpPt.z = 0.0;
+
     fSatisfies *fPtr(a_fsat), tmpFsat(m_rTree->size());
     if (!fPtr)
       fPtr = &tmpFsat;


### PR DESCRIPTION
…the point that we use to search.