### PR TITLE
Auto4 release 7.0

### DIFF
--- a/_package/xms/grid/__init__.py
+++ b/_package/xms/grid/__init__.py
@@ -3,4 +3,4 @@ from . import geometry  # NOQA: F401
 from . import triangulate  # NOQA: F401
 from . import ugrid  # NOQA: F401
 
-__version__ = '7.8.2'
+__version__ = '7.8.3'

--- a/xmsgrid/triangulate/detail/TrAutoFixFourTrianglePts.cpp
+++ b/xmsgrid/triangulate/detail/TrAutoFixFourTrianglePts.cpp
@@ -119,6 +119,7 @@ void TrAutoFixFourTrianglePtsImpl::Fix(BSHP<TrTin> a_tin)
   RenumberTris();
   RemovePts();
   RemoveTris();
+  m_tin->BuildTrisAdjToPts();
 } // TrOuterTriangleDeleterImpl::Fix
 //------------------------------------------------------------------------------
 /// \brief Finds and removes the points connected to 4 triangles


### PR DESCRIPTION
minor fix to TrAutoFixFourTrianglePts.cpp to rebuild the adjacent triangles after removing points and triangles.