### PR TITLE
Bump xmscore to 7.0.6

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -12,7 +12,7 @@ if (NOT MSVC)
 endif()
 """
 
-xms_dependencies = [{ name = "xmscore", version = "7.0.5" }]
+xms_dependencies = [{ name = "xmscore", version = "7.0.6" }]
 
 python_namespaced_dir = "grid"
 


### PR DESCRIPTION
## Summary
- Bump xmscore dependency from 7.0.5 to 7.0.6

## Test plan
- CI builds and tests pass with updated dependency