### PR TITLE
Refresh C++ and Python developer documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,12 @@ wheelhouse/
 cmake-build-*/
 
 # ── Documentation ──────────────────────────────
-Doxygen/
+# Generated Doxygen output directories. The Doxygen/ directory itself is
+# tracked because it holds the source markdown tutorials, Doxyfile, CSS,
+# and image assets used to build the docs.
+Doxygen/html/[!i]*
+Doxygen/latex/
+Doxygen/xml/
 doc/_build/
 doxy_warn.log
 pydocs/build/

--- a/Doxygen/DoxygenMainpage.md
+++ b/Doxygen/DoxygenMainpage.md
@@ -19,7 +19,7 @@ xmsgrid is a grid geometry library used in xms libraries and products.
 License {#XmsgridLicense}
 -------
 
-The code is distributed under the FreeBSD Software License. (See accompanying file LICENSE or copy at [http://www.aquaveo.com/bsd/LICENSE.txt](http://www.aquaveo.com/bsd/license.txt)). 
+The code is distributed under the FreeBSD Software License. (See accompanying file LICENSE or copy at [http://www.aquaveo.com/bsd/LICENSE.txt](http://www.aquaveo.com/bsd/license.txt)).
 
 Python
 ------
@@ -35,6 +35,35 @@ The following tutorials are available:
 * [2D UGrid Tutorial](TwoD_Tutorial.md)
 * [3D UGrid Tutorial](ThreeD_Tutorial.md)
 * [UGrid File IO Tutorial](FileIO_Tutorial.md)
+* [Geometry Tutorial](Geometry_Tutorial.md)
+* [Triangulate Tutorial](Triangulate_Tutorial.md)
+
+Library Modules {#XmsgridModules}
+---------------
+
+The library is organized into the following modules. The unstructured grid (UGrid)
+module is the main entry point for most consumers; the other modules provide
+supporting geometric, triangulation, and linear-algebra primitives.
+
+* **ugrid** - Unstructured grid representation (xms::XmUGrid), edges
+  (xms::XmEdge), and IO/modification utilities (XmUGridUtils.h: read/write,
+  clip, remove points/cells).
+* **geometry** - Geometric primitives and spatial searches:
+  * xms::GmExtents3d - 3D bounding extents.
+  * xms::GmPolygon - Polygon representation and operations.
+  * xms::GmPtSearch - Spatial search for points.
+  * xms::GmTriSearch - Spatial search for triangles, with interpolation
+    weight extraction.
+  * xms::GmMultiPolyIntersector - Intersect a line segment with multiple
+    polygons in 2D.
+  * xms::GmPolyLinePtRedistributer - Redistribute points along a polyline.
+  * Free functions in geoms.h for common geometric operations.
+* **triangulate** - Triangulation utilities:
+  * xms::TrTin - Triangulated irregular network (TIN) representation.
+  * xms::TrTriangulator / xms::TrTriangulatorPoints - Build a TIN from
+    points.
+  * xms::TrBreaklineAdder - Insert breaklines into an existing TIN.
+* **matrices** - Lightweight matrix utilities used by other modules.
 
 Testing {#XmsgridTesting}
 -------
@@ -46,6 +75,12 @@ The Code {#XmsgridTheCode}
 ### Namespaces {#XmsgridNamespaces}
 * "xms" - Most code is in this namespace. The use of other namespaces is kept to a minimum. Two-letter prefixes are used as "pseudo-namespaces" in code modules. Preprocessor macros typically start with "XM_" to prevent name collisions.
 * "xmt" - Testing code will be put into this namespace once CXX_TEST is upgraded such that it will find the testing code in this namespace.
+
+### Module prefixes {#XmsgridPrefixes}
+The two-letter prefixes used in this library follow these conventions:
+* `Xm` - Top-level xms types (e.g. xms::XmUGrid, xms::XmEdge).
+* `Gm` - Geometry module types (e.g. xms::GmPolygon, xms::GmTriSearch).
+* `Tr` - Triangulation module types (e.g. xms::TrTin, xms::TrTriangulator).
 
 ### Interface pattern {#XmsgridInterfacePattern}
 Many classes follow the interface pattern. An abstract base class is used to define the interface and a concrete implementation class is used to implement the functionality. The implementation class will be named the same as the interface class but will end in "Impl" and will only be found in the .cpp file. For example: xms::XmUGrid and xms::XmUGridImpl.

--- a/Doxygen/FileIO_Tutorial.md
+++ b/Doxygen/FileIO_Tutorial.md
@@ -4,16 +4,67 @@
 # UGrid File IO Tutorial {#FileIO_Tutorial}
 
 ## Introduction {#Intro_FileIO}
-The purpose of this tutorial is to provide explanation on how to use File IO with xmsgrid. The XmUGrid class does not have file IO members.  Functions are available in the files named XmUGridUtils to provide File IO.
+The purpose of this tutorial is to provide explanation on how to use File IO
+with xmsgrid. The xms::XmUGrid class itself does not have file IO members;
+instead, free functions in `XmUGridUtils.h` provide IO and bulk-modification
+helpers. This tutorial covers reading and writing UGrids and the modification
+utilities (point/cell removal, clipping) that are most commonly used together
+with IO.
 
 ## Example - Writing UGrid data to ASCII file format {#Example_XmWriteUGridFromAsciiFile}
-This example shows how to write an exisiting UGrid to an ASCII file using function xms::XmWriteUGridToAsciiFile(). This function takes a XmUGrid and filename with path. The testing code for this example is XmUGridUtilsTests::testWriteThenReadUGridFileToAscii.
+This example shows how to write an existing UGrid to an ASCII file using function xms::XmWriteUGridToAsciiFile. This function takes a XmUGrid and filename with path. The testing code for this example is XmUGridUtilsTests::testWriteThenReadUGridFileToAscii.
 
 ## Example - Reading a UGrid from ASCII file format {#Example_XmReadUGridFromAsciiFile}
 This example shows how to read a UGrid from an ASCII file using function xms::XmReadUGridFromAsciiFile. This function takes a filename with path and returns an XmUGrid. The testing code for this example is XmUGridUtilsTests::testWriteThenReadUGridFileToAscii.
 
-
-
 \snippet xmsgrid/ugrid/XmUGridUtils.cpp snip_test_WriteReadAscii
 
-
+## Example - Streaming UGrid data {#Example_XmStreamingUGrid}
+For callers that need to read or write to a stream rather than a file path,
+xmsgrid exposes stream-based overloads:
+
+* xms::XmReadUGridFromStream(std::istream&) - construct a UGrid from any
+  input stream.
+* xms::XmWriteUGridToStream(std::shared_ptr<XmUGrid>, std::ostream&) - write a
+  UGrid to an output stream.
+* xms::XmWriteUGridToStream(const XmUGrid&, std::ostream&, bool a_binary) -
+  write a UGrid to an output stream, optionally using a more compact binary
+  format. Streams written in binary form must be read back through the stream
+  overload of `XmReadUGridFromStream`.
+
+These functions implement the file-path versions above and are useful for
+in-memory round-trip serialization (e.g. in tests) or for embedding a UGrid
+inside a larger document.
+
+## Example - Removing Points from a UGrid {#Example_XmRemovePoints}
+The xms::XmRemovePoints function returns a new UGrid with the specified
+points removed. Cells that referenced any of the removed points are removed
+as well. There is an overload that also returns the set of cell indices that
+were removed so callers can update parallel data structures (e.g. cell
+attributes). Point and cell indices in the returned UGrid are renumbered to
+be contiguous.
+
+## Example - Removing Cells from a UGrid {#Example_XmRemoveCells}
+The xms::XmRemoveCells function returns a new UGrid with the specified cells
+removed. By default the points referenced by the removed cells are retained,
+but passing `a_deleteOrphanedPoints = true` causes any points that no longer
+belong to a cell to be removed as well. An overload also returns the set of
+point indices that were deleted.
+
+## Example - Removing Points and Cells Together {#Example_XmRemovePointsAndCells}
+For more advanced workflows, xms::XmRemovePointsAndCells provides direct
+access to the underlying construction primitives. It takes a UGrid plus the
+sets of point and cell indices to remove and returns the resulting points
+vector and cellstream by reference. Callers can then construct a new UGrid
+from those primitives or compose them with other modifications. The supplied
+point and cell removal sets must be consistent: removing a point without
+also removing its adjacent cells is not handled.
+
+## Example - Clipping a UGrid to Loops {#Example_XmClipUGrid}
+The xms::XmClipUGrid function (declared in `xmsgrid/ugrid/detail/UGridClipper.h`,
+included transitively by `XmUGridUtils.h`) returns a new UGrid clipped to a
+collection of polygonal loops. Each loop is a vector of point indices into
+the input UGrid. Boundary loops should be supplied in clockwise order, while
+interior holes should be supplied in counter-clockwise order. Cells that fall
+outside the boundary loops or inside hole loops are removed from the
+returned grid.

--- a/Doxygen/FileIO_Tutorial.md
+++ b/Doxygen/FileIO_Tutorial.md
@@ -58,7 +58,10 @@ sets of point and cell indices to remove and returns the resulting points
 vector and cellstream by reference. Callers can then construct a new UGrid
 from those primitives or compose them with other modifications. The supplied
 point and cell removal sets must be consistent: removing a point without
-also removing its adjacent cells is not handled.
+also removing every cell that references it triggers an `XM_ASSERT` in
+debug builds and is undefined behavior in release builds. When in doubt,
+prefer xms::XmRemovePoints (which derives the cell set automatically) or
+xms::XmRemoveCells with `a_deleteOrphanedPoints = true`.
 
 ## Example - Clipping a UGrid to Loops {#Example_XmClipUGrid}
 The xms::XmClipUGrid function (declared in `xmsgrid/ugrid/detail/UGridClipper.h`,

--- a/Doxygen/Geometry_Tutorial.md
+++ b/Doxygen/Geometry_Tutorial.md
@@ -176,10 +176,13 @@ Refer to the header for the full list and exact signatures.
 
 ### Vectors and angles
 
-* xms::gmTurn - returns `TURN_LEFT`, `TURN_RIGHT`, `TURN_NONE`, or
-  `TURN_COLINEAR_180` for three points. The optional angle tolerance
-  controls when nearly-collinear configurations are flagged. Used heavily
-  by xmsextractor's triangle traversal code.
+* xms::gmTurn - returns one of `TURN_LEFT`, `TURN_RIGHT`,
+  `TURN_COLINEAR_180` (the three points lie on a line and the third
+  continues past the second), or `TURN_COLINEAR_0` (the third point
+  doubles back along the segment). The optional angle tolerance
+  controls when nearly-collinear configurations are flagged as one of
+  the colinear values. Used heavily by xmsextractor's triangle
+  traversal code.
 * xms::gmCross2D / xms::gmCross3D - 2D and 3D cross products.
 * xms::gmAngleBetweenEdges - CCW angle (0..2pi) between two edges sharing
   a vertex.

--- a/Doxygen/Geometry_Tutorial.md
+++ b/Doxygen/Geometry_Tutorial.md
@@ -1,0 +1,218 @@
+# Geometry Tutorial
+
+\tableofcontents
+# Geometry Tutorial {#Geometry_Tutorial}
+
+## Introduction {#Intro_Geometry}
+
+The `xmsgrid/geometry` module supplies the geometric primitives, spatial
+indexes, and free functions used throughout xmsgrid and by the consuming
+xms libraries (xmsinterp, xmsmesher, xmsextractor, xmsstamper). This tutorial
+covers the parts of the module that are most commonly consumed from outside
+xmsgrid. For grid-level geometry queries (cell centroid, cell extents, plan
+view polygon) see the [2D](TwoD_Tutorial.md) and [3D](ThreeD_Tutorial.md) UGrid
+tutorials.
+
+## Factory Convention {#Geometry_FactoryConvention}
+
+Most xmsgrid classes follow the interface pattern: an abstract base class is
+the only public type, and a static `New()` member returns a `BSHP<T>`
+(boost shared pointer) to the concrete `Impl` instance. Examples in the
+geometry module:
+
+* xms::GmTriSearch::New()
+* xms::GmPtSearch::New(bool a_2dSearch)
+* xms::GmPolygon::New()
+* xms::GmMultiPolyIntersector::New(points, polys, sorter, startingId)
+
+Because consumers only ever hold the shared pointer, copying and assigning
+these types is disabled. Always create instances through `New()`; never
+attempt to construct them directly.
+
+The notable exception is xms::TrTriangulatorPoints, which is a concrete
+class with a public constructor (see the [Triangulate
+Tutorial](Triangulate_Tutorial.md)).
+
+## Spatial Search: GmTriSearch {#Geometry_GmTriSearch}
+
+xms::GmTriSearch indexes a set of triangles for point-in-triangle and
+envelope-overlap queries, and exposes interpolation-weight helpers. The
+typical workflow is:
+
+1. Create the searcher with xms::GmTriSearch::New().
+2. Hand it the points and triangle indices via xms::GmTriSearch::TrisToSearch.
+   Both arguments are `BSHP<>` containers that the searcher *holds by
+   reference*; the caller must keep them alive for the lifetime of the
+   searcher.
+3. Optionally restrict which points or triangles participate via
+   xms::GmTriSearch::SetPtActivity / xms::GmTriSearch::SetTriActivity. The
+   activity is a `DynBitset` (one bit per point or per triangle) where bit
+   `i` set to true means index `i` is active.
+4. Query with xms::GmTriSearch::TriContainingPt,
+   xms::GmTriSearch::TriEnvelopsContainingPt, or
+   xms::GmTriSearch::TriEnvelopesOverlap. Use
+   xms::GmTriSearch::InterpWeights or
+   xms::GmTriSearch::InterpWeightsTriangleIdx to retrieve barycentric
+   interpolation weights at a point.
+
+This is the spatial backbone of xmsinterp's linear and natural-neighbor
+interpolators. xmsextractor uses it to look up the cell that contains an
+extraction point.
+
+## Spatial Search: GmPtSearch {#Geometry_GmPtSearch}
+
+xms::GmPtSearch indexes a set of points for nearest-neighbor and
+within-distance queries. The boolean argument to xms::GmPtSearch::New
+selects the index dimensionality:
+
+* `New(true)` builds a 2D R-tree (the Z component is ignored). Use this
+  when "nearest" is measured in plan view.
+* `New(false)` builds a 3D R-tree.
+
+Pass the points to xms::GmPtSearch::PtsToSearch (held by reference). For
+incremental construction, use xms::GmPtSearch::VectorThatGrowsToSearch
+together with xms::GmPtSearch::AddPtToVectorIfUnique, which only inserts
+points that are not within tolerance of an existing one. Activity is
+controlled with xms::GmPtSearch::SetActivity / xms::GmPtSearch::GetActivity.
+
+Common queries:
+
+* xms::GmPtSearch::NearestPtsToPt - find the N points closest to a given
+  point, with an optional quad/oct-tree mode that biases the result to be
+  spread across quadrants/octants rather than clustered.
+* xms::GmPtSearch::PtsWithinDistanceToPtInRtree - all points within a given
+  distance.
+* xms::GmPtSearch::PtInRTree - check whether a point already exists within
+  tolerance.
+
+## Polygons: GmPolygon {#Geometry_GmPolygon}
+
+xms::GmPolygon wraps a `boost::geometry::polygon` so callers can avoid a
+direct boost dependency. Construct with xms::GmPolygon::New, then call
+xms::GmPolygon::Setup with the outer boundary and a list of inner
+boundaries (holes). After setup the polygon can:
+
+* Test point containment with xms::GmPolygon::CoveredBy (boundary counts as
+  inside) or xms::GmPolygon::Within (strict interior).
+* Compute distance from a point to the polygon boundary with
+  xms::GmPolygon::MinDistanceToBoundary.
+* Combine with another polygon via xms::GmPolygon::Intersection or
+  xms::GmPolygon::Union, both of which return a vector of result polygons.
+
+## Multi-polygon Intersection: GmMultiPolyIntersector {#Geometry_GmMultiPolyIntersector}
+
+xms::GmMultiPolyIntersector intersects a 2D line segment with many
+polygons at once and reports the polygons that the segment crossed in the
+order it crossed them. This is used by xmsmesher (mesh generation across
+domains), xmsextractor (extraction-line traversal), and xmsstamper.
+
+The factory takes four arguments:
+
+* `a_points` - one shared point list referenced by every polygon.
+* `a_polys` - polygons described as 0-based index lists into `a_points`. The
+  first point is **not** repeated as the last point.
+* `a_sorter` - a `BSHP<GmMultiPolyIntersectionSorter>` that decides how the
+  raw intersection events are ordered. The standard choice is
+  xms::GmMultiPolyIntersectionSorterTerse, which produces a compact
+  enter/exit run per polygon. The sorter is decoupled from the intersector
+  so callers can substitute alternative orderings without re-implementing
+  the geometry.
+* `a_startingId` - id of the first polygon (default 1). A returned id of
+  `-1` is the special end marker.
+
+Use xms::GmMultiPolyIntersector::SetQuery to switch between
+`GMMPIQ_COVEREDBY` (segment must be covered by the polygon) and
+`GMMPIQ_INTERSECTS` (any non-empty intersection counts). The
+xms::GmMultiPolyIntersector::TraverseLineSegment overloads return the
+sequence of polygon ids, plus optionally the parametric `t` values along
+the line and/or the actual intersection points. xms::GmMultiPolyIntersector::PolygonFromPoint
+returns the id of the polygon containing a single point.
+
+## Polyline Redistribution: GmPolyLinePtRedistributer {#Geometry_GmPolyLinePtRedistributer}
+
+xms::GmPolyLinePtRedistributer redistributes the points along a polyline to
+target a desired spacing. Construct with `New()`, supply the polyline, and
+call the redistribute method to receive a new polyline whose vertices are
+spaced at (approximately) the requested distance.
+
+## Free Functions in geoms.h {#Geometry_FreeFunctions}
+
+`xmsgrid/geometry/geoms.h` contains a large set of free functions for low
+level geometric tests. The most commonly consumed ones are listed below.
+Refer to the header for the full list and exact signatures.
+
+### Tolerance management
+
+* xms::gmGetXyTol / xms::gmSetXyTol - read or override the global 2D
+  tolerance used by helpers that don't take an explicit `tol`.
+* xms::gmEqualPointsXY - compare two `Pt3d`s in plan view (Z ignored)
+  within tolerance.
+
+### Polygon and area
+
+* xms::gmPointInPolygon2D - return +1 inside, 0 on boundary, -1 outside.
+* xms::gmPolygonArea - signed plan-view area; positive for CCW polygons.
+* xms::gmComputePolygonCentroid - plan-view centroid of a non
+  self-intersecting polygon.
+
+### Lines and segments
+
+* xms::gmOnLineWithTol - test whether a point lies on the infinite line
+  through two points.
+* xms::gmOnLineAndBetweenEndpointsWithTol - same, but constrained to the
+  segment.
+* xms::gmInsideOrOnLineWithTol / xms::gmInsideOfLineWithTol - half-plane
+  tests against a reference point.
+* xms::gmLinesIntersect - boolean segment-segment intersection.
+* xms::gmIntersectLineSegmentsWithTol - segment-segment intersection that
+  also returns the intersection coordinates and z-values from each
+  segment. Prefer xms::gmIntersectLineSegments where the tolerance variant
+  is not required (the comment in `geoms.cpp` flags subtle behavior in the
+  `WithTol` variant).
+* xms::gmFindClosestPtOnSegment / xms::gmPtDistanceAlongSegment - project a
+  point onto a segment.
+* xms::gm2DDistanceToLineSegmentWithTol / xms::gm2DDistanceToLineWithTol -
+  distance helpers.
+
+### Vectors and angles
+
+* xms::gmTurn - returns `TURN_LEFT`, `TURN_RIGHT`, `TURN_NONE`, or
+  `TURN_COLINEAR_180` for three points. The optional angle tolerance
+  controls when nearly-collinear configurations are flagged. Used heavily
+  by xmsextractor's triangle traversal code.
+* xms::gmCross2D / xms::gmCross3D - 2D and 3D cross products.
+* xms::gmAngleBetweenEdges - CCW angle (0..2pi) between two edges sharing
+  a vertex.
+* xms::gmBisectingAngle, xms::gmPerpendicularAngle, xms::gmConvertAngleToBetween0And360
+  - angle utilities used by mesh smoothing and stamping.
+
+### Triangle helpers
+
+* xms::gmIntersectTriangleAndLineSegment - intersect a 3D triangle with a
+  line segment; used by xmsstamper for surface clipping.
+* xms::gmBaryPrepare / xms::gmCartToBary - precompute and apply
+  barycentric coordinate transforms, used by interpolation.
+
+### Extents
+
+* xms::gmExtents2D / xms::gmExtents3D - bounding box from a point set.
+  Despite the name, xms::gmExtents2D operates on `Pt3d` inputs and simply
+  ignores Z.
+* xms::gmAddToExtents - grow an existing min/max pair to include a new
+  point.
+
+## Reference vs. Copy Semantics {#Geometry_ReferenceSemantics}
+
+Several geometry classes hold the input data by reference rather than
+copying it:
+
+* xms::GmTriSearch::TrisToSearch - holds the supplied points and triangle
+  vectors by `BSHP<>`.
+* xms::GmPtSearch::PtsToSearch and xms::GmPtSearch::VectorThatGrowsToSearch
+  - same.
+* xms::TrTriangulatorPoints - holds references to the caller's `points`
+  and output `tris` / `trisAdjToPts` (see Triangulate tutorial).
+
+Callers must keep these vectors alive (and unmodified, where applicable)
+for the lifetime of the dependent object. Mutating the underlying vector
+while a search is active will produce undefined behavior.

--- a/Doxygen/ThreeD_Tutorial.md
+++ b/Doxygen/ThreeD_Tutorial.md
@@ -6,12 +6,16 @@
 ## Introduction {#Intro_3Ugrid}
 The purpose of this tutorial is to provide explanation on how to use xmsgrid to create three dimensional unstructured grids, or UGrids. A UGrid has points and cells defined using those points. There are many different kinds of cells available, but this tutorial will focus on the 3-dimensional cells, namely: tetrahedron, voxel, hexahedron, wedge, pyramid, and polyhedron.
 
+For 2D-only concepts (plan-view polygons, edge adjacency for a single 2D cell)
+see the [2D UGrid Tutorial](TwoD_Tutorial.md). For IO and modification
+utilities see the [UGrid File IO Tutorial](FileIO_Tutorial.md).
+
 ## Example - Defining Ugrid Cells {#Example_DefiningA3dUGridCell}
-Supported 3D grid cells include: tetrahedron (10), voxel (11), hexahedron (12), wedge (13), pyramid (14), and polyhedron (42). A cell is defined with the number declaration of the shape (10, 11, 12, 13, 14, and 42, respectively, as defined by the enumeration xms::XmUGridCellType), then the number of points, followed by the point indices.  The cell definitions mirror VTK cell definitions which are available on page 9 of VTK File Formats for VTK version 4.2 at https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf. 
+Supported 3D grid cells include: tetrahedron (10), voxel (11), hexahedron (12), wedge (13), pyramid (14), and polyhedron (42). A cell is defined with the number declaration of the shape (10, 11, 12, 13, 14, and 42, respectively, as defined by the enumeration xms::XmUGridCellType), then the number of points, followed by the point indices. The cell definitions mirror VTK cell definitions which are available on page 9 of VTK File Formats for VTK version 4.2 at https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf.
 
 A tetrahedron (10) has 4 points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_TETRA for point order. A cellstream example for a tetrahedron is: 10, 4, 0, 1, 2, 3.
 
-A voxel (11) has 8 orthogonially defined points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_VOXEL for point order. A cellstream example for a voxel is: 11, 8, 0, 1, 2, 3, 4, 5, 6, 7.
+A voxel (11) has 8 orthogonally defined points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_VOXEL for point order. A cellstream example for a voxel is: 11, 8, 0, 1, 2, 3, 4, 5, 6, 7.
 
 A hexahedron (12) has 8 points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_HEXAHEDRON for point order. A cellstream example for a hexahedron is: 12, 8, 0, 1, 2, 3, 4, 5, 6, 7.
 
@@ -19,7 +23,7 @@ A wedge (13) has 6 points. See the illustration in the VTK file Format pdf refer
 
 A pyramid (14) has 5 points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_PYRAMID for point order. A cellstream example for a pyramid is: 14, 5, 0, 1, 2, 3, 4.
 
-A polyhedron (42) does not a have a defined number of points. A polyhedron cellstream has the following format: The cell type, number of faces, and then repeated for each face: the number of points in the face, followed by the points in the face declared in a counter-clockwise (ccw) direction (as viewed from outside the solid). A cellstream example for a polyhedron representation of a cube defined with points (10, 11, 12, 13) on the top face and points (14, 15, 16, 17) on the bottom face as viewed from above with points ordered clockwise from the lower left as viewed from above) is: 42, 6, 4, 10, 13, 12, 11, 4, 10, 11, 15, 14, 4, 11, 12, 16, 15, 4, 12, 13, 17, 16, 4, 13, 10, 14, 17, 4, 14, 15, 16, 17.  (42 is the type number, 6 is the number of faces, 4 is the number of points in the first face, those points are: 10, 13, 12, 11 in ccw order from the outside, 4 is the number of points on the next face, 10, 11, 15, 14 are the point indices of that face in ccw order, and so on.)
+A polyhedron (42) does not a have a defined number of points. A polyhedron cellstream has the following format: The cell type, number of faces, and then repeated for each face: the number of points in the face, followed by the points in the face declared in a counter-clockwise (ccw) direction (as viewed from outside the solid). A cellstream example for a polyhedron representation of a cube defined with points (10, 11, 12, 13) on the top face and points (14, 15, 16, 17) on the bottom face as viewed from above with points ordered clockwise from the lower left as viewed from above) is: 42, 6, 4, 10, 13, 12, 11, 4, 10, 11, 15, 14, 4, 11, 12, 16, 15, 4, 12, 13, 17, 16, 4, 13, 10, 14, 17, 4, 14, 15, 16, 17. (42 is the type number, 6 is the number of faces, 4 is the number of points in the first face, those points are: 10, 13, 12, 11 in ccw order from the outside, 4 is the number of points on the next face, 10, 11, 15, 14 are the point indices of that face in ccw order, and so on.)
 
 The testing code for this example is in TEST_XmUGrid3DLinear.
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_3DShapes
@@ -30,17 +34,28 @@ This example shows how to create a new 3D UGrid with the overloaded New function
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_NewOperator
 
 ## Example - Creating a New 3D UGrid {#Example_New3d}
-This example shows how to create a new 3D UGrid. XmUGrid is an abstract class that cannot be instantiated. The static function xms::XmUGrid::New is the only method to obtain a Boost Shared Pointer to an instance of XmUGrid. Points and Cellstream may be passed to New to initialize the UGrid with data but this is not required. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testUGridStreams.
+This example shows how to create a new 3D UGrid. The static function xms::XmUGrid::New returns a `std::shared_ptr<XmUGrid>`. Points and a cellstream may be passed to `New` to initialize the UGrid with data, but this is not required. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testUGridStreams.
 
 ## Example - Setting the UGrid Points {#Example_SetPoints3d}
-This example shows how to set all of the UGrid points using xms::XmUGrid::SetLocations. The Ugrid points cannot be added or removed individually, though they can be edited individually. The SetPoints function takes one argument, a vector of 3D points. It is reccomended that each point is unique to avoid unexpected behavior. Functionality is shared between 2d and 3d UGrids. The testing code for this example is the same as used for creating a new UGrid, XmUGridUnitTests::testUGridStreams.
+This example shows how to set all of the UGrid points using xms::XmUGrid::SetLocations. The UGrid points cannot be added or removed individually, though they can be edited individually. The SetLocations function takes one argument, a vector of 3D points. It is recommended that each point is unique to avoid unexpected behavior. Functionality is shared between 2d and 3d UGrids. The testing code for this example is the same as used for creating a new UGrid, XmUGridUnitTests::testUGridStreams.
 
 ## Example - Setting the UGrid Cell Stream {#Example_SetCellstream3d}
 This example shows how to set the entire UGrid Cellstream using xms::XmUGrid::SetCellstream. Cellstreams are formatted as a stream of integers starting with the cell type as described by the enumeration XmUGridCellType, then the number of points in the cell, followed by a series of indices to points. The SetCellstream function takes one argument, a vector of integers formatted as previously described. Functionality is shared between 2d and 3d UGrids. The testing code for this example is the same as used for creating a new UGrid, XmUGridUnitTests::testUGridStreams.
 
-The xms::XmUGrid::IsValidCellstream function checks whether all cell types and point counts within the cellstream match up, but does not check for orientation or valid point positions. This function should not be relied on to catch all errors, but can be a basic check before setting the cellstream. The function takes one arguement, a cellstream containing one or more cells. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::SetCellstream.
+The xms::XmUGrid::IsValidCellstream function checks whether all cell types and point counts within the cellstream match up, but does not check for orientation or valid point positions. This function should not be relied on to catch all errors, but can be a basic check before setting the cellstream. Prefer the overload that accepts the number of points (`IsValidCellstream(cellstream, pointCount)`); the single-argument overload is deprecated because it cannot fully validate point indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::SetCellstream.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_UGrid_Streams
+
+## Example - Cell Ordering of a Layered 3D UGrid {#Example_CellOrdering3d}
+For 3D UGrids built up from stacked layers, xmsgrid can record whether the
+layer index increases as you move up or down through the grid. The enumeration
+xms::XmUGridCellOrdering distinguishes XMU_CELL_ORDER_INCREASING_DOWN,
+XMU_CELL_ORDER_INCREASING_UP, and XMU_CELL_ORDER_UNKNOWN. Use
+xms::XmUGrid::GetCellOrdering to read the current setting,
+xms::XmUGrid::SetCellOrdering to override it, and
+xms::XmUGrid::CalculateCellOrdering to compute the ordering from cell
+geometry. The cell ordering is required for face-orientation queries (top vs.
+bottom) on prismatic cells.
 
 ## Example - Get Number Of Points {#Example_GetPointCount3d}
 This example shows how to return the number of points contained in a UGrid. The xms::XmUGrid::GetPointCount function returns the number of points in the UGrid. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
@@ -52,24 +67,34 @@ This example shows how to get all points contained within the XmUGrid. The xms::
 This example shows how to get a specific point given a point index. The xms::XmUGrid::GetPointLocation function returns the Pt3d of the point at the specified index. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Set Point Location {#Example_SetLocation3d}
-This example shows how to set a specific point given a point index. The xms::XmUGrid::SetLocation function takes a point index and a Pt3d as arguements and returns whether the operation was succesful. The function may fail and return false if the change would cause any edges to cross. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to set a specific point given a point index. The xms::XmUGrid::SetPointLocation function takes a point index and a Pt3d as arguments and returns whether the operation was successful. The function may fail and return false if the change would cause any edges to cross. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get Locations of an Array of Points {#Example_GetPointsLocations3d}
-This example shows how to convert a vector of point indices into a vector of Pt3d's. The xms::XmUGrid::GetPointsLocations function takes a vector of Point Indices as an arguement and returns a vector of corresponding Pt3d's as a result. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to convert a vector of point indices into a vector of Pt3d's. The xms::XmUGrid::GetPointsLocations function takes a vector of Point Indices as an argument and returns a vector of corresponding Pt3d's as a result. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get GetExtents of UGrid {#Example_GetExtents3d}
-This example shows how to get the extents of a UGrid. The xms::XmUGrid::GetExtents function takes two 3D points as arguements describing the minimum and maximum extent that the points of the UGrid cover. These arguments will be set by the funtion. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to get the extents of a UGrid. The xms::XmUGrid::GetExtents function takes two 3D points as arguments describing the minimum and maximum extent that the points of the UGrid cover. These arguments will be set by the function. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get Cells Associated with a Point {#Example_PointCells3d}
-This example shows how to the cells associated with a single point. The xms::XmUGrid::GetPointCells function takes one point index as an arguement and returns a vector of point indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to get the cells associated with a single point. The xms::XmUGrid::GetPointAdjacentCells function takes one point index as an argument and returns a vector of cell indices. Use xms::XmUGrid::GetPointAdjacentCellCount to query just the count. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get the Cells that Share the Same Point or Points {#Example_GetPointsAdjacentCells3d}
-This example shows how to the cells that share the same point or points. The xms::XmUGrid::GetPointsAdjacentCells function takes a vector of point indices as an arguement and returns a vector of cell indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to get the cells that share the same point or points. The xms::XmUGrid::GetPointsAdjacentCells function takes a vector of point indices as an argument and returns a vector of cell indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_PointFunctions
 
+## Example - Get the Points Adjacent to a Point {#Example_GetPointAdjacentPoints3d}
+This example shows how to get the points connected to a given point by an
+edge. The xms::XmUGrid::GetPointAdjacentPoints function takes a point index
+and returns a vector of point indices, while
+xms::XmUGrid::GetPointAdjacentLocations returns the corresponding Pt3d
+locations. Functionality is shared between 2d and 3d UGrids. The testing code
+for this example is in XmUGridUnitTests::testGetPointAdjacentPoints.
+
+\snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetPointAdjacentPoints
+
 ## Example - Get the Points of a Cell {#Example_GetCellPointsLocations3d}
-This example shows how to get the points of a cell. The xms::XmUGrid::GetCellPoints function takes one cell index and returns a vector of point indices. There is also a The xms::XmUGrid::GetCellLocations function that returns the locations (Pt3d) of those points.  Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
+This example shows how to get the points of a cell. The xms::XmUGrid::GetCellPoints function takes one cell index and returns a vector of point indices. The xms::XmUGrid::GetCellLocations function returns the locations (Pt3d) of those points. Use xms::XmUGrid::GetCellPointCount to query just the number of points in a cell. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
 
 ## Example - Get the Type of a Cell {#Example_GetCellType3d}
 This example shows how to get the type of a cell. The xms::XmUGrid::GetCellType function takes one cell index and returns the cell type. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
@@ -80,13 +105,19 @@ This example shows how to get the count of the dimensions of cells used in a UGr
 ## Example - Get the Dimension of a Cell {#Example_GetCellDimension3d}
 This example shows how to get the dimension of a cell. The xms::XmUGrid::GetCellDimension function takes one cell index and returns the cell dimension as an integer value. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
 
+## Example - Get the Extents of a Cell {#Example_GetCellExtents3d}
+This example shows how to get the bounding extents of a single cell. The xms::XmUGrid::GetCellExtents function takes a cell index and two Pt3d output arguments which are set to the minimum and maximum extents of the cell. Functionality is shared between 2d and 3d UGrids.
+
+## Example - Get the Centroid of a Cell {#Example_GetCellCentroid3d}
+This example shows how to compute the centroid of a cell. The xms::XmUGrid::GetCellCentroid function takes a cell index and a Pt3d output argument which is set to the centroid location. The function returns true if the centroid could be computed. Functionality is shared between 2d and 3d UGrids.
+
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellFunctions
 
 ## Example - Get the Cellstream of the UGrid {#Example_GetCellstream3d}
-This example shows how to get the entire cellstream of the UGrid. The xms::XmUGrid::GetCellStream function returns a vector of integers that is the cellstream. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
+This example shows how to get the entire cellstream of the UGrid. The xms::XmUGrid::GetCellstream function returns a vector of integers that is the cellstream. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
 
 ## Example - Get a Single Cellstream for One Cell {#Example_GetCellCellstream3d}
-This example shows how to get the cellstream for just one cell. The xms::XmUGrid::GetCellCellstream function takes a cell index and a vector of integers that is the cellstream for the specified cell passed in by reference. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
+This example shows how to get the cellstream for just one cell. The xms::XmUGrid::GetCellCellstream function takes a cell index and a vector of integers that is the cellstream for the specified cell passed in by reference. Use xms::XmUGrid::GetCellCellstreamIndex to find a cell's offset within the underlying cellstream. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellstreamFunctions
 
@@ -96,7 +127,7 @@ This example shows how to get the cells that also use any of the points of a giv
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetCellAdjacentCells
 
 ## Example - Get a Plan View Polygon {#Example_GetCellPlanViewPolygon3d}
-This example shows how to get a plan view polygon. This function first assumes that the shape is prismatic (or that the sides of the shape are vertical) and it gathers the points of the vertical sides. If this method fails, it builds a convex hull of the unique points of the shape. If the second method is employed, concave shapes will result in a convex polygon. The xms::XmUGrid::GetCellPlanViewPolygon function takes a cell index and a vector of Pt3d to contain on return the locations of the points of the plan view polygon and returns whether the operation was succesful. The testing code for this example is XmUGridUnitTests::testGetCellPlanViewPolygon.
+This example shows how to get a plan view polygon. This function first assumes that the shape is prismatic (or that the sides of the shape are vertical) and it gathers the points of the vertical sides. If this method fails, it builds a convex hull of the unique points of the shape. If the second method is employed, concave shapes will result in a convex polygon. The xms::XmUGrid::GetCellPlanViewPolygon function takes a cell index and a vector of Pt3d to contain on return the locations of the points of the plan view polygon and returns whether the operation was successful. The testing code for this example is XmUGridUnitTests::testGetCellPlanViewPolygon.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetCellPlanViewPolygon
 
@@ -109,7 +140,7 @@ This example shows how to get all cells which share the specified edge with a ce
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellEdgeAdjacentCellFunctions
 
 ## Example Get Edges Associated with a Cell {#Example_GetCellEdges3d}
-This example shows how to get edges associated with a cell. The xms::XmUGrid::GetCellEdges function takes a cell index and returns a vector of XmEdge (each of with contains a pairs of integers which are point indices). Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testCellEdges
+This example shows how to get edges associated with a cell. The xms::XmUGrid::GetCellEdges function takes a cell index and returns a vector of XmEdge (each of which contains a pair of integers which are point indices). Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testCellEdges
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellEdges
 
@@ -117,6 +148,9 @@ This example shows how to get edges associated with a cell. The xms::XmUGrid::Ge
 This example shows how to get the number of faces that a cell has. The xms::XmUGrid::GetCell3dFaceCount function takes a cell index and returns the number of cell faces associated with it as an integer. The testing code for this example is XmUGridUnitTests::testCell3dFaceFunctions
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetNumberOfCellFaces
+
+## Example Get Number of Points on a Cell Face {#Example_GetCell3dFacePointCount3d}
+This example shows how to get the number of points that bound a particular face of a 3D cell. The xms::XmUGrid::GetCell3dFacePointCount function takes a cell index and a face index and returns the number of points in that face. The testing code for this example is shared with another example, XmUGridUnitTests::testCell3dFaceFunctions.
 
 ## Example Get Cell Face {#Example_GetCell3dFacePoints3d}
 This example shows how to get a cell face. The xms::XmUGrid::GetCell3dFacePoints function takes a cell index and a face index and returns a vector of point indices which define the face in counter-clockwise direction. The testing code for this example is shared with another example, XmUGridUnitTests::testCell3dFaceFunctions.
@@ -126,9 +160,16 @@ This example shows how to get all the faces of a cell. The xms::XmUGrid::GetCell
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_Cell3dFaceFunctions
 
-## Example Get Cell Face Ajacent Cell {#Example_GetCell3dFaceAdjacentCell3d}
-This example shows how to get the cell, if any, which shares a face with a specified cell and face. The xms::XmUGrid::GetCell3dFaceAdjacentCell function takes a cell index and a face index and return the cell index of the cell which shares the face, or -1 if there are none. There is an overload which takes a cell index, a face index, an integer which it will set to be the cell index if any of the adjacent cell, and an integer which it will set to be the index of the face of the adjacent cell which it shares with the specified cell if any, and returns true if there is a cell with a shared face. The testing code for this example is XmUGridUnitTests::testGetCell3dFaceAdjacentCell.
+## Example Get Cell Face Adjacent Cell {#Example_GetCell3dFaceAdjacentCell3d}
+This example shows how to get the cell, if any, which shares a face with a specified cell and face. The xms::XmUGrid::GetCell3dFaceAdjacentCell function takes a cell index and a face index and returns the cell index of the cell which shares the face, or -1 if there are none. There is an overload which takes a cell index, a face index, an integer which it will set to be the cell index of the adjacent cell if any, and an integer which it will set to be the index of the face of the adjacent cell which it shares with the specified cell if any, and returns true if there is a cell with a shared face. The testing code for this example is XmUGridUnitTests::testGetCell3dFaceAdjacentCell.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetCell3dFaceAdjacentCell
 
-
+## Example Get Cell Face Orientation {#Example_GetCell3dFaceOrientation3d}
+For prismatic cells in a layered 3D UGrid the orientation of each face is one
+of side, top, or bottom. The xms::XmUGrid::GetCell3dFaceOrientation function
+takes a cell index and a face index and returns a value of the
+xms::XmUGridFaceOrientation enumeration. The result depends on the cell
+ordering recorded on the grid (see [Cell Ordering of a Layered 3D
+UGrid](#Example_CellOrdering3d)); if the cell ordering is unknown the
+function returns XMU_ORIENTATION_UNKNOWN.

--- a/Doxygen/Triangulate_Tutorial.md
+++ b/Doxygen/Triangulate_Tutorial.md
@@ -1,0 +1,149 @@
+# Triangulate Tutorial
+
+\tableofcontents
+# Triangulate Tutorial {#Triangulate_Tutorial}
+
+## Introduction {#Intro_Triangulate}
+
+The `xmsgrid/triangulate` module provides:
+
+* xms::TrTin - a triangulated irregular network (TIN) with topology and
+  the modifiers needed to maintain it.
+* xms::TrTriangulator (abstract) and xms::TrTriangulatorPoints (concrete)
+  - build triangles from a point cloud.
+* xms::TrBreaklineAdder - insert constraint lines into an existing TIN.
+
+These types are used by xmsmesher (mesh generation), xmsinterp (linear and
+natural-neighbor surfaces), and xmsstamper (terrain modification). The
+patterns they share are documented here.
+
+## TrTin: Lifecycle {#Triangulate_TrTinLifecycle}
+
+xms::TrTin follows the interface pattern: the only public type is the
+abstract base class, and instances are created via xms::TrTin::New() which
+returns a `BSHP<TrTin>`. After construction the TIN is empty; populate it
+in one of three ways:
+
+1. Call xms::TrTin::SetPoints, xms::TrTin::SetTriangles, and
+   xms::TrTin::SetTrianglesAdjacentToPoints separately. Each setter takes
+   a `BSHP<>` to the underlying vector and stores the pointer; the TIN
+   *shares ownership* with the caller. This means later mutations to the
+   vector via the original pointer are visible to the TIN.
+2. Call xms::TrTin::SetGeometry to install all three at once.
+3. Set only points (without triangles), then run a triangulator (see
+   below) writing into xms::TrTin::TrianglesPtr().
+
+xms::TrTin::BuildTrisAdjToPts rebuilds the adjacency table from the current
+points and triangles - call this after manually editing triangles when you
+also need topology queries (xms::TrTin::AdjacentTriangle,
+xms::TrTin::TriangleAdjacentToEdge, xms::TrTin::CommonEdgeIndex, etc.).
+
+xms::TrTin::Clear empties all three vectors in place.
+
+### Common queries
+
+* xms::TrTin::Points / xms::TrTin::Triangles / xms::TrTin::TrisAdjToPts -
+  references to the underlying vectors.
+* xms::TrTin::NumPoints / xms::TrTin::NumTriangles - sizes.
+* xms::TrTin::GetExtents - bounding box.
+* xms::TrTin::GetBoundaryPoints / xms::TrTin::GetBoundaryPolys - boundary
+  topology.
+* xms::TrTin::TriangleCentroid / xms::TrTin::TriangleArea - per-triangle
+  geometry.
+* xms::TrTin::LocalIndex / xms::TrTin::GlobalIndex - convert between
+  per-triangle local point indices (0-2) and global point indices.
+* xms::TrTin::VerticesAreAdjacent - test whether two points share a
+  triangle edge.
+
+### Modifiers
+
+* xms::TrTin::SwapEdge - swap the diagonal between two triangles that
+  form a convex quadrilateral. By default the call refuses to swap when
+  the resulting triangles would be very thin; pass `a_checkAngle = false`
+  to override.
+* xms::TrTin::OptimizeTriangulation - iteratively swap edges until the
+  triangulation is Delaunay.
+* xms::TrTin::DeleteTriangles / xms::TrTin::DeletePoints - remove and
+  renumber.
+* xms::TrTin::RemoveLongThinTrianglesOnPerimeter - clean up sliver
+  triangles around the boundary.
+
+### Serialization
+
+xms::TrTin::ExportTinFile writes a TIN file. xms::TrTin::ToString and
+xms::TrTin::FromString round-trip a TIN through a string for use with
+boost serialization.
+
+## Building a TIN: TrTriangulatorPoints {#Triangulate_TrTriangulatorPoints}
+
+xms::TrTriangulatorPoints is the only concrete xms::TrTriangulator
+implementation in xmsgrid. **Unlike the rest of xmsgrid, this type is not
+created via a factory; it has a public constructor**:
+
+\code{.cpp}
+xms::VecPt3d points = ...;
+xms::VecInt   triangles;             // out parameter; will be populated
+xms::VecInt2d trisAdjToPts;          // optional out parameter
+xms::TrTriangulatorPoints tri(points, triangles, &trisAdjToPts);
+tri.Triangulate();                    // fills triangles and trisAdjToPts
+\endcode
+
+Important contract:
+
+* `points` is held by const reference; do not destroy it before calling
+  Triangulate().
+* `triangles` is held by non-const reference and is **populated by
+  Triangulate**. Pass an empty vector unless you have a specific reason
+  to seed it.
+* `trisAdjToPts` is an optional pointer. Pass `nullptr` if adjacency is
+  not needed.
+* The triangulator may also be plugged into a TIN via
+  xms::TrTin::TrianglesPtr() / xms::TrTin::PointsPtr() to triangulate the
+  TIN's points in place.
+
+xmsinterp's Python bindings invoke this constructor implicitly when the
+user supplies points without triangles; xmsmesher uses it during mesh
+generation.
+
+## Adding Constraints: TrBreaklineAdder {#Triangulate_TrBreaklineAdder}
+
+xms::TrBreaklineAdder inserts constraint edges (breaklines) into an
+existing TIN, which is needed to enforce features like ridge lines, river
+banks, or mesh boundary requirements. Workflow:
+
+1. Build a TIN from the relevant points (often via TrTriangulatorPoints
+   followed by xms::TrTin::OptimizeTriangulation).
+2. Create the adder with xms::TrBreaklineAdder::New().
+3. Call xms::TrBreaklineAdder::SetTin to attach a `BSHP<TrTin>` and
+   optionally override the geometric tolerance (a value <= 0 selects an
+   automatic tolerance based on the TIN's extents).
+4. Call xms::TrBreaklineAdder::AddBreakline (single polyline as a list of
+   point indices) or xms::TrBreaklineAdder::AddBreaklines (multiple).
+5. Inspect xms::TrBreaklineAdder::ErrorMessage for any per-breakline
+   diagnostics.
+
+Once the adder finishes, the TIN has had its triangulation modified so
+that every breakline edge is present. The TIN's points and triangle
+vectors are mutated in place.
+
+## Free Helpers {#Triangulate_FreeHelpers}
+
+* xms::trRenumberOnDelete - remap indices in a vector after a deletion
+  pass; used internally and exposed for callers that need to update
+  parallel data when removing points or triangles.
+* xms::trSwapEdgeWithMinAngle - convenience wrapper around
+  xms::TrTin::SwapEdge that only swaps when the resulting minimum angle
+  exceeds the supplied threshold.
+* xms::trBuildGridGeomFromTin (declared in
+  `xmsgrid/triangulate/triangles.h`) and other helpers in `triangles.h` -
+  small utilities used when bridging to the UGrid representation.
+
+## TrTin to XmUGrid {#Triangulate_TinToUGrid}
+
+A TIN is a flat triangulation; an xms::XmUGrid is a richer unstructured
+grid that supports mixed cell types, faces, and 3D topology. xmsgrid does
+not provide a built-in TIN-to-UGrid converter, but the conversion is
+straightforward: build a cellstream of `[XMU_TRIANGLE, 3, p0, p1, p2]`
+entries from xms::TrTin::Triangles and pass it to
+xms::XmUGrid::New(points, cellstream). xmsmesher's
+`meiUGridFromTin` is one example of a thin wrapper around this conversion.

--- a/Doxygen/Triangulate_Tutorial.md
+++ b/Doxygen/Triangulate_Tutorial.md
@@ -101,9 +101,10 @@ Important contract:
   xms::TrTin::TrianglesPtr() / xms::TrTin::PointsPtr() to triangulate the
   TIN's points in place.
 
-xmsinterp's Python bindings invoke this constructor implicitly when the
-user supplies points without triangles; xmsmesher uses it during mesh
-generation.
+The Python `xms.grid.triangulate.Tin` class wraps this constructor inside
+its `triangulate()` method, so Python callers run the same algorithm by
+calling `tin.triangulate()` after constructing a Tin from points alone.
+xmsmesher uses xms::TrTriangulatorPoints directly during mesh generation.
 
 ## Adding Constraints: TrBreaklineAdder {#Triangulate_TrBreaklineAdder}
 

--- a/Doxygen/TwoD_Tutorial.md
+++ b/Doxygen/TwoD_Tutorial.md
@@ -6,6 +6,12 @@
 ## Introduction {#Intro_2Ugrid}
 The purpose of this tutorial is to provide explanation on how to use xmsgrid to create two dimensional unstructured grids, or UGrids. A UGrid has points and cells defined using those points. There are many different kinds of cells available, but this tutorial will focus on the 2-dimensional cells, namely: triangle, polygon, pixel, quadrilateral.
 
+Most UGrid functionality is shared between 2D and 3D grids. The examples in
+this tutorial therefore reuse the same xms::XmUGrid API documented in the
+[3D UGrid Tutorial](ThreeD_Tutorial.md). For IO and modification utilities
+(read/write, clip, remove points/cells) see the
+[UGrid File IO Tutorial](FileIO_Tutorial.md).
+
 ## Example - Defining Ugrid Cells {#Example_DefiningA2dUGridCell}
 Supported 2D grid cells include: triangle (5), polygon (7), pixel (8), quad (9). A cell is defined with the number declaration of the shape (5, 7, 8, and 9 respectively as defined by the enumeration xms::XmUGridCellType), then the number of points, followed by the point indices. The cell definitions mirror VTK cell definitions which are available on page 9 of VTK File Formats for VTK version 4.2 at https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf.
 
@@ -13,7 +19,7 @@ A triangle (5) has 3 points and the points are declared in a counter-clockwise d
 
 A polygon (7) does not a have a defined number of points, but the points are still declared in a counter-clockwise direction. A cellstream example for a polygon is: 7, 5, 0, 1, 2, 3, 4.
 
-A pixel (8) has 4 orthogonially defined points. For the direction and order of points, see the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_PIXEL. A cellstream example for a pixel is: 8, 4, 0, 1, 2, 3.
+A pixel (8) has 4 orthogonally defined points. For the direction and order of points, see the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_PIXEL. A cellstream example for a pixel is: 8, 4, 0, 1, 2, 3.
 
 A quad (9) has 4 points declared in a counter-clockwise direction. A cellstream example for a quad is: 9, 4, 0, 1, 2, 3.
 
@@ -26,15 +32,15 @@ This example shows how to create a new 2D UGrid with the overloaded New function
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_NewOperator
 
 ## Example - Creating a New 2D UGrid {#Example_New2d}
-This example shows how to create a new 2D UGrid. XmUGrid is an abstract class that cannot be instantiated. The static function xms::XmUGrid::New() is the only method to obtain a Boost Shared Pointer to an instance of XmUGrid. Points and Cellstream may be passed to New to initialize the UGrid with data but this is not required. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testUGridStreams.
+This example shows how to create a new 2D UGrid. The static function xms::XmUGrid::New() returns a `std::shared_ptr<XmUGrid>`. Points and a cellstream may be passed to `New` to initialize the UGrid with data, but this is not required. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testUGridStreams.
 
 ## Example - Setting the UGrid Points {#Example_SetPoints2d}
-This example shows how to set all of the UGrid points using xms::XmUGrid::SetLocations. The Ugrid points cannot be added or removed individually, though they can be edited individually. The SetPoints function takes one argument, a vector of 3D points. It is recomended that each point is unique to avoid unexpected behavior. Functionality is shared between 2d and 3d UGrids. The testing code for this example is the same as used for creating a new UGrid, XmUGridUnitTests::testUGridStreams.
+This example shows how to set all of the UGrid points using xms::XmUGrid::SetLocations. The UGrid points cannot be added or removed individually, though they can be edited individually. The SetLocations function takes one argument, a vector of 3D points. It is recommended that each point is unique to avoid unexpected behavior. Functionality is shared between 2d and 3d UGrids. The testing code for this example is the same as used for creating a new UGrid, XmUGridUnitTests::testUGridStreams.
 
 ## Example - Setting the UGrid Cell Stream {#Example_SetCellstream2d}
 This example shows how to set the entire UGrid Cellstream using xms::XmUGrid::SetCellstream. Cellstreams are formatted as a stream of integers starting with the cell type as described by the enumeration XmUGridCellType, then the number of points in the cell, followed by a series of indices to points. The SetCellstream function takes one argument, a vector of integers formatted as previously described. Functionality is shared between 2d and 3d UGrids. The testing code for this example is the same as used for creating a new UGrid, XmUGridUnitTests::testUGridStreams.
 
-The xms::XmUGrid::IsValidCellstream function checks whether all cell types and point counts within the cellstream match up, but does not check for orientation or valid point positions. This function should not be relied on to catch all errors, but can be a basic check before setting the cellstream. The function takes one argument, a cellstream containing one or more cells. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::SetCellstream.
+The xms::XmUGrid::IsValidCellstream function checks whether all cell types and point counts within the cellstream match up, but does not check for orientation or valid point positions. This function should not be relied on to catch all errors, but can be a basic check before setting the cellstream. Prefer the overload that accepts the number of points in the grid (`IsValidCellstream(cellstream, pointCount)`); the single-argument overload is deprecated because it cannot fully validate point indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::SetCellstream.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_UGrid_Streams
 
@@ -47,17 +53,23 @@ This example shows how to get all points contained within the XmUGrid. The xms::
 ## Example - Get Point Location {#Example_GetPointLocation}
 This example shows how to get a specific point given a point index. The xms::XmUGrid::GetPointLocation function returns the Pt3d of the point at the specified index. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
+## Example - Get Point Location With Z = 0 {#Example_GetPointXy0}
+This example shows how to get a point's location with z forced to 0.0. The xms::XmUGrid::GetPointXy0 function takes a point index and returns the Pt3d of that point with z = 0.0. This is useful for 2D operations that should ignore the elevation of the points. Functionality is shared between 2d and 3d UGrids.
+
 ## Example - Set Point Location {#Example_SetLocation}
-This example shows how to set a specific point location given a point index. The xms::XmUGrid::SetLocation function takes a point index and a Pt3d as arguments and returns whether the operation was succesful. The function will fail and return false if the change would cause any edges to cross. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to set a specific point location given a point index. The xms::XmUGrid::SetPointLocation function takes a point index and a Pt3d as arguments and returns whether the operation was successful. The function will fail and return false if the change would cause any edges to cross. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+
+## Example - Check If a Point Change Is Valid {#Example_IsValidPointChange}
+This example shows how to check whether moving a point would invalidate the grid without actually moving it. The xms::XmUGrid::IsValidPointChange function takes a point index and a candidate Pt3d location and returns true if no edge crossings would result. This is useful when interactively moving points to provide feedback before committing the change. Functionality is shared between 2d and 3d UGrids.
 
 ## Example - Get Locations of Many Points {#Example_GetPointsLocations}
 This example shows how to convert a vector of point indices into a vector of Pt3d's. The xms::XmUGrid::GetPointsLocations function takes a vector of Point Indices as an argument and returns a vector of corresponding Pt3d's as a result. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get Extents of UGrid {#Example_GetExtents}
-This example shows how to get the extents of a UGrid. The xms::XmUGrid::GetExtents function takes two 3D points as arguments describing the minimum and maximum extent that the points of the UGrid cover. These arguments will be set by the funtion. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to get the extents of a UGrid. The xms::XmUGrid::GetExtents function takes two 3D points as arguments describing the minimum and maximum extent that the points of the UGrid cover. These arguments will be set by the function. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get Cells Adjacent to a Point {#Example_GetPointAdjacentCells}
-This example shows how to the cells associated with a single point. The xms::XmUGrid::GetPointAdjacentCells function takes one point index as an argument and returns a vector of cell indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
+This example shows how to get the cells associated with a single point. The xms::XmUGrid::GetPointAdjacentCells function takes one point index as an argument and returns a vector of cell indices. Use xms::XmUGrid::GetPointAdjacentCellCount to query just the count without allocating a vector. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
 
 ## Example - Get the Cells that Share All of Group of Points {#Example_GetPointsAdjacentCells}
 This example shows how to get the cells that share all of the same points or points. The xms::XmUGrid::GetPointsAdjacentCells function takes a vector of point indices as an argument and returns a vector of cell indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testPointFunctions.
@@ -65,12 +77,12 @@ This example shows how to get the cells that share all of the same points or poi
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_PointFunctions
 
 ## Example - Get the Points (or their Locations) Adjacent to Point {#Example_GetPointAdjacentPoints}
-This example shows how to get the Points that are adjacent to a given point. The xms::XmUGrid::GetPointAdjacentPoints functions takes a point index as an argument and returns the indices of the adjacent Points.  The function xms::XmUGrid::GetPointAdjacentLocations returns instead the locations of the adjacent points.  The testing code for this example is in XmUGridUnitTests::testGetPointAdjacentPoints.
+This example shows how to get the Points that are adjacent to a given point. The xms::XmUGrid::GetPointAdjacentPoints function takes a point index as an argument and returns the indices of the adjacent Points. The function xms::XmUGrid::GetPointAdjacentLocations returns instead the locations of the adjacent points. The testing code for this example is in XmUGridUnitTests::testGetPointAdjacentPoints.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetPointAdjacentPoints
 
 ## Example - Get the Points or Locations of a Cell {#Example_GetCellPointsLocations}
-This example shows how to get the points of a cell. The xms::XmUGrid::GetCellPoints function takes one cell index and returns a vector of point indices. The xms::XmUGrid::GetCellLocations functions takes a cell index and returns a VecPt3d of the locations of those points.  Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
+This example shows how to get the points of a cell. The xms::XmUGrid::GetCellPoints function takes one cell index and returns a vector of point indices. The xms::XmUGrid::GetCellLocations function takes a cell index and returns a VecPt3d of the locations of those points. Use xms::XmUGrid::GetCellPointCount to query just the number of points in a cell. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
 
 ## Example - Get the Type of a Cell {#Example_GetCellType}
 This example shows how to get the type of a cell. The xms::XmUGrid::GetCellType function takes one cell index and returns the cell type. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
@@ -81,13 +93,19 @@ This example shows how to get the count of the dimensions of cells used in a UGr
 ## Example - Get the Dimension of a Cell {#Example_GetCellDimension}
 This example shows how to get the dimension of a cell. The xms::XmUGrid::GetCellDimension function takes one cell index and returns the cell dimension as an integer value. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellFunctions.
 
+## Example - Get the Extents of a Cell {#Example_GetCellExtents}
+This example shows how to get the bounding extents of a single cell. The xms::XmUGrid::GetCellExtents function takes a cell index and two Pt3d output arguments which are set to the minimum and maximum extents of the cell. Functionality is shared between 2d and 3d UGrids.
+
+## Example - Get the Centroid of a Cell {#Example_GetCellCentroid}
+This example shows how to compute the centroid of a cell. The xms::XmUGrid::GetCellCentroid function takes a cell index and a Pt3d output argument which is set to the centroid location. The function returns true if the centroid could be computed. Functionality is shared between 2d and 3d UGrids.
+
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellFunctions
 
 ## Example - Get the Cellstream of the UGrid {#Example_GetCellstream}
-This example shows how to get the entire cellstream of the UGrid. The xms::XmUGrid::GetCellStream function returns a vector of integers that is the cellstream. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
+This example shows how to get the entire cellstream of the UGrid. The xms::XmUGrid::GetCellstream function returns a vector of integers that is the cellstream. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
 
 ## Example - Get a the Cellstream for Single Cell {#Example_GetCellCellstream}
-This example shows how to get the cellstream for one cell. The xms::XmUGrid::GetCellCellstream function takes a cell index and a vector of integers that is the cellstream for the specified cell passed in by reference. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
+This example shows how to get the cellstream for one cell. The xms::XmUGrid::GetCellCellstream function takes a cell index and a vector of integers that is the cellstream for the specified cell passed in by reference. Use xms::XmUGrid::GetCellCellstreamIndex to obtain the offset of a cell within the underlying cellstream. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellstreamFunctions.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellstreamFunctions
 
@@ -97,7 +115,7 @@ This example shows how to get the cells adjacent to a given cell. Cells are adja
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetCellAdjacentCells
 
 ## Example - Get a Plan View Polygon {#Example_GetCellPlanViewPolygon}
-This example shows how to get a plan view polygon. The xms::XmUGrid::GetCellPlanViewPolygon function takes a cell index and a vector of Pt3d which is the points of the 2D cell and returns whether the operation was succesful. The testing code for this example is XmUGridUnitTests::testGetCellPlanViewPolygon.
+This example shows how to get a plan view polygon. The xms::XmUGrid::GetCellPlanViewPolygon function takes a cell index and a vector of Pt3d which is the points of the 2D cell and returns whether the operation was successful. The testing code for this example is XmUGridUnitTests::testGetCellPlanViewPolygon.
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_GetCellPlanViewPolygon
 
@@ -112,15 +130,21 @@ This example shows how to get the cell edge from a given cell and edge index. Th
 ## Example Get Cells Adjacent to an Edge of a Cell {#Example_GetCellEdgeAdjacentCells}
 This example shows how to get all cells which share the specified edge with a cell. The xms::XmUGrid::GetCellEdgeAdjacentCells function takes a cell index and an edge index and returns a vector of cell indices. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellEdgeAdjacentCellFunctions
 
-## Example 2D Get the Other Cell Adjacent to a particular Cell Edge{#Example_GetCell2dEdgeAdjacentCell}
+## Example 2D Get the Other Cell Adjacent to a particular Cell Edge {#Example_GetCell2dEdgeAdjacentCell}
 This example shows how to get a 2D cell which is adjacent to another given 2D cell with a given edge index. The xms::XmUGrid::GetCell2dEdgeAdjacentCell function takes a cell index and an edge index and returns a cell index, since no more than one cell may legally share an edge in this manner. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellEdgeAdjacentCellFunctions
 
 ## Example Get Cells Adjacent to a Given Edge {#Example_GetEdgeAdjacentCells}
 This example shows how to get all cells which contain a given edge. The xms::XmUGrid::GetEdgeAdjacentCells function takes two point indices describing an edge and returns a vector of cell indices. There is also an overload which takes a pair of point indices describing an edge. Functionality is shared between 2d and 3d UGrids. The testing code for this example is shared with other examples, XmUGridUnitTests::testCellEdgeAdjacentCellFunctions
 
-\snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellEdgeAdjacentCellFunctions
-
 ## Example Get Edges of a Cell {#Example_GetCellEdges}
 This example shows how to get edges associated with a cell. The xms::XmUGrid::GetCellEdges function takes a cell index and returns a vector of XmEdge (each of which has a pair of integers which are point indices of the Edge). Functionality is shared between 2d and 3d UGrids. The testing code for this example is XmUGridUnitTests::testCellEdges
 
 \snippet xmsgrid/ugrid/XmUGrid.cpp snip_test_CellEdges
+
+## Example - Caching and Modification State {#Example_CacheAndModified}
+For grids that are queried often, the UGrid maintains internal caches that
+accelerate adjacency lookups. Use xms::XmUGrid::SetUseCache to opt in or out of
+caching. xms::XmUGrid::GetModified returns true when the grid has been mutated
+since it was created or since the last call to xms::XmUGrid::SetUnmodified.
+These flags are useful when synchronizing derived data structures with the
+grid. Functionality is shared between 2d and 3d UGrids.

--- a/pydocs/source/conf.py
+++ b/pydocs/source/conf.py
@@ -121,7 +121,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'xmsinterpdoc'
+htmlhelp_basename = 'xmsgriddoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -148,7 +148,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'xmsinterp.tex', 'xmsinterp Documentation',
+    (master_doc, 'xmsgrid.tex', 'xmsgrid Documentation',
      'aquaveo', 'manual'),
 ]
 
@@ -158,7 +158,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'xmsinterp', 'xmsinterp Documentation',
+    (master_doc, 'xmsgrid', 'xmsgrid Documentation',
      [author], 1)
 ]
 
@@ -169,8 +169,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'xmsinterp', 'xmsinterp Documentation',
-     author, 'xmsinterp', 'Interpolation library used by aquaveo libraries.',
+    (master_doc, 'xmsgrid', 'xmsgrid Documentation',
+     author, 'xmsgrid', 'Grid library used by aquaveo libraries.',
      'Miscellaneous'),
 ]
 

--- a/pydocs/source/getting_started.rst
+++ b/pydocs/source/getting_started.rst
@@ -56,8 +56,7 @@ Round-trip a UGrid through the ASCII file format::
    assert loaded == grid
 
 Usage and documentation for each class can be found in the **User Interface**
-section of this site. Additional examples are available on the project's
-`Examples_ <https://github.com/Aquaveo/xmsgrid/tree/master/examples>`_ page,
-including the ``UGrids.ipynb`` notebook.
-
-.. _Examples: https://github.com/Aquaveo/xmsgrid/tree/master/examples
+section of this site. Additional examples are available in the project's
+`examples directory
+<https://github.com/Aquaveo/xmsgrid/tree/master/examples>`_, including the
+``UGrids.ipynb`` notebook.

--- a/pydocs/source/getting_started.rst
+++ b/pydocs/source/getting_started.rst
@@ -3,20 +3,61 @@ Installation
 
 XmsGrid can be installed using `Anaconda <https://www.anaconda.com/download/>`_.
 
-You can install XmsGrid using the `conda <https://www.anaconda.com/download/>`_ command::
+Install with ``conda`` from the ``aquaveo`` channel::
 
    conda install -c aquaveo xmsgrid
 
-This will install XmsGrid and **all** the needed dependencies.
-
+This will install xmsgrid and **all** the needed dependencies.
 
 Usage
 -----
 
-The XmsGrid library contains classes for defining geometric grids that can be used in other
-Aquaveo libraries.
+The xmsgrid library contains classes for defining geometric grids that can be
+used in other Aquaveo libraries.
 
-Usage and documentation for each class can be found in the **User Interface** section
-of this site. There are also additional examples that can be found on the Examples_ page
+The most common entry points are:
 
-.. _Examples: https://aquaveo.github.io/examples/xmsinterp/xmsinterp.html
+* :class:`xms.grid.ugrid.UGrid` -- a 0/1/2/3-D unstructured grid built from a
+  list of points and a VTK-style cellstream.
+* :mod:`xms.grid.ugrid.ugrid_utils` -- read/write UGrids and apply bulk
+  modifications (remove points/cells, clip to loops).
+* :class:`xms.grid.triangulate.Tin` -- a triangulated irregular network.
+* :class:`xms.grid.geometry.MultiPolyIntersector` and
+  :class:`xms.grid.geometry.TriSearch` -- spatial queries.
+* :mod:`xms.grid.geometry.geometry` -- free functions for low-level 2D
+  geometry (point-in-polygon, polygon area, etc.).
+
+Quick Start
+-----------
+
+Build a small UGrid programmatically and inspect it::
+
+   from xms.grid.ugrid import UGrid
+
+   points = [
+       (0.0, 0.0, 0.0),
+       (1.0, 0.0, 0.0),
+       (1.0, 1.0, 0.0),
+       (0.0, 1.0, 0.0),
+   ]
+   # Cell type 9 (quad) with 4 points: 0, 1, 2, 3
+   cellstream = [9, 4, 0, 1, 2, 3]
+
+   grid = UGrid(points=points, cellstream=cellstream)
+   print(grid.point_count, grid.cell_count)
+   print(grid.get_cell_locations(0))
+
+Round-trip a UGrid through the ASCII file format::
+
+   from xms.grid.ugrid import ugrid_utils
+
+   ugrid_utils.write_ugrid_to_ascii_file(grid, "grid.ugrid")
+   loaded = ugrid_utils.read_ugrid_from_ascii_file("grid.ugrid")
+   assert loaded == grid
+
+Usage and documentation for each class can be found in the **User Interface**
+section of this site. Additional examples are available on the project's
+`Examples_ <https://github.com/Aquaveo/xmsgrid/tree/master/examples>`_ page,
+including the ``UGrids.ipynb`` notebook.
+
+.. _Examples: https://github.com/Aquaveo/xmsgrid/tree/master/examples

--- a/pydocs/source/index.rst
+++ b/pydocs/source/index.rst
@@ -7,16 +7,24 @@
 XmsGrid |version|
 *****************
 
-**Last Updated:** April 5, 2019
+The xmsgrid library is a grid library for other Aquaveo products. It provides
+classes and utilities for creating and manipulating unstructured grids
+(``UGrid``), triangulated irregular networks (``Tin``), and supporting
+geometric primitives such as polygon intersection and triangle search.
 
-The xmsgrid library is a grid library for other aquaveo products. This library
-contains classes used to create grids.
+The Python package is named ``xms.grid`` and is organized into three
+sub-modules:
+
+* :mod:`xms.grid.ugrid` -- Unstructured grid creation, query, and IO.
+* :mod:`xms.grid.geometry` -- Geometric primitives, free functions, and
+  spatial searches.
+* :mod:`xms.grid.triangulate` -- Triangulated irregular networks (TINs).
 
 Examples
 ========
 
-The examples for this library can be found in the
-examples folder in the `github repository <https://github.com/Aquaveo/xmsgrid>`_
+Runnable examples for this library can be found in the ``examples`` folder of
+the `GitHub repository <https://github.com/Aquaveo/xmsgrid>`_.
 
 Index
 =====
@@ -36,6 +44,7 @@ Index
 
 * :doc:`modules/ugrid/UGrid`
 * :doc:`modules/ugrid/ugrid_utils`
+* :doc:`modules/geometry/geometry`
 * :doc:`modules/geometry/MultiPolyIntersector`
 * :doc:`modules/geometry/TriSearch`
 * :doc:`modules/triangulate/Tin`
@@ -47,6 +56,7 @@ Index
 
    modules/ugrid/UGrid.rst
    modules/ugrid/ugrid_utils.rst
+   modules/geometry/geometry.rst
    modules/geometry/MultiPolyIntersector.rst
    modules/geometry/TriSearch.rst
    modules/triangulate/Tin.rst
@@ -54,4 +64,5 @@ Index
 Acknowledgements
 ================
 
-This library is from work done by aquaveo developers to support other aquaveo libraries.
+This library is the work of Aquaveo developers and supports other Aquaveo
+libraries (xmsinterp, xmsmesh, xmsstamper, xmsextractor, etc.).

--- a/pydocs/source/modules/geometry/MultiPolyIntersector.rst
+++ b/pydocs/source/modules/geometry/MultiPolyIntersector.rst
@@ -2,7 +2,25 @@
 MultiPolyIntersector
 ********************
 
-Intersects a line segment with any number of polygons in 2D and returns the polygons in order with t values.
+Intersects a 2D line segment with any number of polygons and returns the
+polygons traversed in order, along with the parametric ``t`` values where
+the segment enters and exits each polygon. This is the same primitive used
+by xmsmesher (mesh generation across domains), xmsextractor (extraction
+line traversal), and xmsstamper.
+
+The polygons are described by a single point list and a list of polygons,
+where each polygon is itself a list of indices into the point list. The
+first point is **not** repeated as the last point. Polygon IDs returned by
+:meth:`traverse_line_segment` are 1-based by default; pass a different
+``starting_id`` to the constructor to change this. The ``query`` argument
+selects the intersection rule (``'covered_by'`` requires the segment to be
+covered by the polygon, ``'intersects'`` accepts any non-empty
+intersection).
+
+The Python wrapper hides the C++ ``GmMultiPolyIntersectionSorter``
+abstraction; results are always returned with the standard "terse"
+ordering (one enter/exit run per polygon). When a polygon id of ``-1``
+appears in the returned id sequence it is the end-of-traversal marker.
 
 .. autoclass:: xms.grid.geometry.MultiPolyIntersector
    :members:

--- a/pydocs/source/modules/geometry/TriSearch.rst
+++ b/pydocs/source/modules/geometry/TriSearch.rst
@@ -2,7 +2,22 @@
 TriSearch
 *********
 
-The TriSearch class is used to create a spatial index for searching triangles.
+Spatial index for searching triangles. Given a set of points and triangles
+(point-index triples), :class:`TriSearch` answers queries such as which
+triangle contains a given point, which triangle envelopes overlap a region,
+and what interpolation weights apply at a query point. It is the spatial
+backbone used by xmsinterp's linear and natural-neighbor interpolators.
+
+Points and triangles can each be selectively activated or deactivated via
+:attr:`point_activity` and :attr:`triangle_activity` so callers can mask
+out portions of the mesh without rebuilding the search. The activity
+sequence has one entry per point (or triangle); a ``True`` value marks the
+index as active.
+
+.. note::
+
+   :class:`TriSearch` holds the supplied points and triangles by reference.
+   Keep the originals alive for as long as the search instance is in use.
 
 .. autoclass:: xms.grid.geometry.TriSearch
    :members:

--- a/pydocs/source/modules/geometry/TriSearch.rst
+++ b/pydocs/source/modules/geometry/TriSearch.rst
@@ -16,8 +16,10 @@ index as active.
 
 .. note::
 
-   :class:`TriSearch` holds the supplied points and triangles by reference.
-   Keep the originals alive for as long as the search instance is in use.
+   The Python wrapper copies the supplied points and triangles into
+   internal C++ buffers when the search is constructed; later edits to
+   the original Python sequences are not seen by the search. To search
+   different data, build a new :class:`TriSearch`.
 
 .. autoclass:: xms.grid.geometry.TriSearch
    :members:

--- a/pydocs/source/modules/geometry/geometry.rst
+++ b/pydocs/source/modules/geometry/geometry.rst
@@ -1,0 +1,25 @@
+********
+geometry
+********
+
+Free functions for low-level 2D geometric operations: point-in-polygon
+tests, polygon area and centroid, line/segment queries, and tolerance
+management. These helpers mirror the C++ free functions declared in
+``xmsgrid/geometry/geoms.h``.
+
+These helpers operate on points represented as ``(x, y, z)`` tuples and
+generally project to the XY plane (the Z component is ignored - even by
+functions named ``..._2d`` that take 3D points). The default tolerance for
+floating-point comparisons can be queried with :func:`get_tol_2d` and
+overridden with :func:`set_tol_2d`; most query functions also accept an
+explicit ``tol`` argument.
+
+.. note::
+
+   :func:`set_tol_2d` updates a process-global tolerance used by every
+   xmsgrid helper that does not receive an explicit ``tol``. Prefer the
+   per-call ``tol`` arguments when a specific section of code needs a
+   different tolerance, and reset the global value if you must change it.
+
+.. automodule:: xms.grid.geometry.geometry
+   :members:

--- a/pydocs/source/modules/triangulate/Tin.rst
+++ b/pydocs/source/modules/triangulate/Tin.rst
@@ -6,14 +6,18 @@ Triangulated irregular network (TIN). The :class:`Tin` class encapsulates
 arrays of points, triangles (as triples of point indices), and adjacency
 information, plus methods to triangulate, optimize, and modify them.
 
-When constructed with ``points`` only, :class:`Tin` runs the
-``TrTriangulatorPoints`` algorithm internally, so callers do not need to
-build triangles themselves before calling :meth:`Tin.triangulate`.
+Constructing :class:`Tin` with ``points`` only stores the points but leaves
+the triangle list empty; call :meth:`Tin.triangulate` to build triangles
+using ``TrTriangulatorPoints`` internally. Constructing with both
+``points`` and ``triangles`` skips that step and uses the triangles
+verbatim.
 
 Common workflows:
 
-* Construct a Tin from a list of points and (optionally) triangles, then call
+* Construct a Tin from a list of points (no triangles) and call
   :meth:`Tin.triangulate` to compute a Delaunay triangulation.
+* Construct a Tin from existing points *and* triangles when the
+  triangulation is already known.
 * Inspect topology with :attr:`Tin.boundary_polys`,
   :meth:`Tin.adjacent_triangle`, :meth:`Tin.triangle_centroid`, etc.
 * Modify with :meth:`Tin.swap_edge`, :meth:`Tin.delete_triangles`,

--- a/pydocs/source/modules/triangulate/Tin.rst
+++ b/pydocs/source/modules/triangulate/Tin.rst
@@ -2,8 +2,28 @@
 Tin
 ***
 
-Class to encapsulate a tin made simply of arrays of points,
-triangles and adjacency information. Also methods to manipulate it.
+Triangulated irregular network (TIN). The :class:`Tin` class encapsulates
+arrays of points, triangles (as triples of point indices), and adjacency
+information, plus methods to triangulate, optimize, and modify them.
+
+When constructed with ``points`` only, :class:`Tin` runs the
+``TrTriangulatorPoints`` algorithm internally, so callers do not need to
+build triangles themselves before calling :meth:`Tin.triangulate`.
+
+Common workflows:
+
+* Construct a Tin from a list of points and (optionally) triangles, then call
+  :meth:`Tin.triangulate` to compute a Delaunay triangulation.
+* Inspect topology with :attr:`Tin.boundary_polys`,
+  :meth:`Tin.adjacent_triangle`, :meth:`Tin.triangle_centroid`, etc.
+* Modify with :meth:`Tin.swap_edge`, :meth:`Tin.delete_triangles`,
+  :meth:`Tin.delete_points`, or :meth:`Tin.optimize_triangulation`.
+* Persist with :meth:`Tin.export_tin_file`.
+
+Note: the :attr:`Tin.points`, :attr:`Tin.triangles`, and
+:attr:`Tin.triangles_adjacent_to_points` setters install the supplied
+sequences directly. After mutating triangles outside the helper API call
+:meth:`Tin.build_triangles_adjacent_to_points` to keep adjacency consistent.
 
 .. autoclass:: xms.grid.triangulate.Tin
    :members:

--- a/pydocs/source/modules/ugrid/UGrid.rst
+++ b/pydocs/source/modules/ugrid/UGrid.rst
@@ -2,10 +2,32 @@
 UGrid
 *****
 
-A class to contain grid geometry.
+A class for representing unstructured grid geometries with 0D, 1D, 2D, and 3D
+cells. Cell connectivity is described with a VTK-compatible cellstream:
+``[cell_type, num_points, p0, p1, ...]`` for ordinary cells, with
+:class:`UGrid.cell_type_enum` providing the cell type constants. For 3D
+polyhedral cells the cellstream uses
+``[cell_type, num_faces, face_0_num_points, face_0_p0, ...]`` per face.
 
 .. autoclass:: xms.grid.ugrid.UGrid
    :members:
 
-   .. attribute:: xms.grid.ugrid.UGrid.cell_type_enum
-      Represent the vtk type of a cell
+   .. attribute:: cell_type_enum
+
+      Enumeration of supported VTK cell types (e.g. ``XMU_TRIANGLE``,
+      ``XMU_QUAD``, ``XMU_HEXAHEDRON``, ``XMU_POLYHEDRON``). Use these values
+      when building or interpreting cellstreams.
+
+   .. attribute:: cell_ordering_enum
+
+      Enumeration of cell orderings for layered 3D UGrids
+      (``XMU_CELL_ORDER_INCREASING_DOWN``, ``XMU_CELL_ORDER_INCREASING_UP``,
+      ``XMU_CELL_ORDER_UNKNOWN``). The cell ordering controls how face
+      orientations (top/bottom/side) are computed for prismatic cells.
+
+   .. attribute:: face_orientation_enum
+
+      Enumeration of face orientations
+      (``XMU_ORIENTATION_TOP``, ``XMU_ORIENTATION_BOTTOM``,
+      ``XMU_ORIENTATION_SIDE``, ``XMU_ORIENTATION_UNKNOWN``). Returned by
+      :meth:`UGrid.get_cell_3d_face_orientation`.

--- a/pydocs/source/modules/ugrid/ugrid_utils.rst
+++ b/pydocs/source/modules/ugrid/ugrid_utils.rst
@@ -2,5 +2,10 @@
 ugrid_utils
 ***********
 
+Utilities for reading and writing UGrids in the ASCII file format and for
+producing modified copies of an existing UGrid (removing points or cells,
+clipping to a set of loops). All functions accept and return
+:class:`xms.grid.ugrid.UGrid` instances.
+
 .. automodule:: xms.grid.ugrid.ugrid_utils
    :members:


### PR DESCRIPTION
## Summary
- Audit Doxygen tutorials and Sphinx pages against the current xmsgrid API and against how xmsinterp/xmsmesher/xmsextractor/xmsstamper consume xmsgrid; fill in the gaps.
- New C++ tutorials for the geometry module (factory convention, GmTriSearch/GmPtSearch, GmPolygon, GmMultiPolyIntersector + sorter, geoms.h free functions, reference semantics) and the triangulate module (TrTin lifecycle, TrTriangulatorPoints' by-reference output contract, TrBreaklineAdder, TrTin->XmUGrid conversion); existing UGrid tutorials gain examples for previously undocumented APIs (Get/SetPointXy0, IsValidPointChange, GetCellExtents, GetCellCentroid, GetCell3dFaceOrientation, XmUGridCellOrdering, etc.) and the FileIO tutorial covers stream IO, XmRemove*, and XmClipUGrid.
- Python Sphinx docs: fix stale "xmsinterp" config strings and the broken examples URL, add a quick-start, document the previously missing xms.grid.geometry.geometry free-function module, and add consumer-facing notes (reference semantics, hidden sorter, implicit triangulation in Tin).
- .gitignore: replace the blanket Doxygen/ rule that was hiding new tutorial sources with rules that only ignore generated build output.

## Test plan
- [ ] Run Doxygen against `Doxygen/Doxyfile` and confirm the new tutorials render and link from the mainpage.
- [ ] Run `make html` from `pydocs/` and confirm the new geometry page builds and the User Interface index renders.