### PR TITLE
Address PR #186 follow-up review issues (#187-#192)

### DIFF
--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -94,7 +94,7 @@ jobs:
           clang --version
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -114,7 +114,7 @@ jobs:
       - name: Get Tag
         id: gitTag
         uses: little-core-labs/get-git-tag@v3.0.2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Set Conan Version
       - name: Set Conan Version
         uses: allenevans/set-env@v2.0.0
@@ -123,7 +123,7 @@ jobs:
           XMS_VERSION: ${{ steps.gitTag.outputs.tag }}
           CONAN_UPLOAD: https://conan.aquaveo.com
           RELEASE_PYTHON: 'True'
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Check for release branch
       - name: Get Branch Name
         id: gitBranch
@@ -145,35 +145,35 @@ jobs:
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform macos
         shell: bash
-        if: matrix.build_type == 'Release'
+        if: ${{ matrix.build_type == 'Release' }}
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ runner.os }}
           path: wheelhouse/*.whl
-        if: matrix.build_type == 'Release'
+        if: ${{ matrix.build_type == 'Release' }}
       # Upload wheel to Aquapi
       - name: Upload wheel to Aquapi
         run: xmsconan_wheel_deploy --wheel-dir wheelhouse
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release'
+        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' }}
       # Upload Release to Conan
       - name: Upload Releases to Conan
         run: "python build.py --skip-build --upload --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\""
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Get the Release Data
       - name: Get Release
         id: git_release
         uses: bruceadams/get-release@v1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.AQUAVEO_GITHUB_TOKEN }}
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Archive Conan Packages
         run: |
           conan cache save --file ${{ env.MATRIX_NAME }}.tar.gz xmsgrid/${{ env.XMS_VERSION }}:*
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Upload Zipped Conan Packages
       - name: Upload Zipped Conan Packages
         uses: actions/upload-release-asset@v1
@@ -184,7 +184,7 @@ jobs:
           asset_path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
           asset_name: ${{ env.MATRIX_NAME }}.tar.gz
           asset_content_type: application/zip
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   # ----------------------------------------------------------------------------------------------
   # LINUX
@@ -227,7 +227,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
@@ -241,7 +241,7 @@ jobs:
       - name: Get Tag
         id: gitTag
         uses: little-core-labs/get-git-tag@v3.0.2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Set Conan Version
       - name: Set Conan Version
         uses: allenevans/set-env@v2.0.0
@@ -250,7 +250,7 @@ jobs:
           XMS_VERSION: ${{ steps.gitTag.outputs.tag }}
           CONAN_UPLOAD: https://conan.aquaveo.com
           RELEASE_PYTHON: 'True'
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Check for release branch
       - name: Get Branch Name
         id: gitBranch
@@ -272,35 +272,35 @@ jobs:
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform linux
         shell: bash
-        if: matrix.build_type == 'Release'
+        if: ${{ matrix.build_type == 'Release' }}
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ runner.os }}
           path: wheelhouse/*.whl
-        if: matrix.build_type == 'Release'
+        if: ${{ matrix.build_type == 'Release' }}
       # Upload wheel to Aquapi
       - name: Upload wheel to Aquapi
         run: xmsconan_wheel_deploy --wheel-dir wheelhouse
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release'
+        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' }}
       # Upload Release to Conan
       - name: Upload Releases to Conan
         run: "python build.py --skip-build --upload --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\""
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Get the Release Data
       - name: Get Release
         id: git_release
         uses: bruceadams/get-release@v1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.AQUAVEO_GITHUB_TOKEN }}
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Archive Conan Packages
         run: |
           conan cache save --file ${{ env.MATRIX_NAME }}.tar.gz xmsgrid/${{ env.XMS_VERSION }}:*
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Upload Zipped Conan Packages
       - name: Upload Zipped Conan Packages
         uses: actions/upload-release-asset@v1
@@ -311,7 +311,7 @@ jobs:
           asset_path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
           asset_name: ${{ env.MATRIX_NAME }}.tar.gz
           asset_content_type: application/zip
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   # ----------------------------------------------------------------------------------------------
   # WINDOWS
@@ -354,7 +354,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -382,7 +382,7 @@ jobs:
       - name: Get Tag
         id: gitTag
         uses: little-core-labs/get-git-tag@v3.0.2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Set Conan Version
       - name: Set Conan Version
         uses: allenevans/set-env@v2.0.0
@@ -391,7 +391,7 @@ jobs:
           XMS_VERSION: ${{ steps.gitTag.outputs.tag }}
           CONAN_UPLOAD: https://conan.aquaveo.com
           RELEASE_PYTHON: 'True'
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Check for release branch
       - name: Get Branch Name
         id: gitBranch
@@ -413,35 +413,35 @@ jobs:
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows
         shell: bash
-        if: matrix.build_type == 'Release'
+        if: ${{ matrix.build_type == 'Release' }}
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
-        if: matrix.build_type == 'Release'
+        if: ${{ matrix.build_type == 'Release' }}
       # Upload wheel to Aquapi
       - name: Upload wheel to Aquapi
         run: xmsconan_wheel_deploy --wheel-dir wheelhouse
         shell: bash
-        if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release'
+        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' }}
       # Upload Release to Conan
       - name: Upload Releases to Conan
         run: "python build.py --skip-build --upload --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\""
         shell: cmd
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Get the Release Data
       - name: Get Release
         id: git_release
         uses: bruceadams/get-release@v1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.AQUAVEO_GITHUB_TOKEN }}
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Archive Conan Packages
         run: |
           conan cache save --file ${{ env.MATRIX_NAME }}.tar.gz xmsgrid/${{ env.XMS_VERSION }}:*
         shell: cmd
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       # Upload Zipped Conan Packages
       - name: Upload Zipped Conan Packages
         uses: actions/upload-release-asset@v1
@@ -452,4 +452,4 @@ jobs:
           asset_path: ${{ github.workspace }}/${{ env.MATRIX_NAME }}.tar.gz
           asset_name: ${{ env.MATRIX_NAME }}.tar.gz
           asset_content_type: application/zip
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ coverage_report/
 
 # ── Local configuration ───────────────────────
 .claude/
-CLAUDE.md
 CLAUDE.local.md
 .envrc
 CMakePresets.json

--- a/Doxygen/ThreeD_Tutorial.md
+++ b/Doxygen/ThreeD_Tutorial.md
@@ -13,6 +13,8 @@ utilities see the [UGrid File IO Tutorial](FileIO_Tutorial.md).
 ## Example - Defining Ugrid Cells {#Example_DefiningA3dUGridCell}
 Supported 3D grid cells include: tetrahedron (10), voxel (11), hexahedron (12), wedge (13), pyramid (14), and polyhedron (42). A cell is defined with the number declaration of the shape (10, 11, 12, 13, 14, and 42, respectively, as defined by the enumeration xms::XmUGridCellType), then the number of points, followed by the point indices. The cell definitions mirror VTK cell definitions which are available on page 9 of VTK File Formats for VTK version 4.2 at https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf.
 
+\note The integer cell-type values shown below are the on-the-wire cellstream format and are kept in sync with VTK and xms::XmUGridCellType. If that enum is ever renumbered or extended, update these examples to match.
+
 A tetrahedron (10) has 4 points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_TETRA for point order. A cellstream example for a tetrahedron is: 10, 4, 0, 1, 2, 3.
 
 A voxel (11) has 8 orthogonally defined points. See the illustration in the VTK file Format pdf referenced above on page 9 for a VTK_VOXEL for point order. A cellstream example for a voxel is: 11, 8, 0, 1, 2, 3, 4, 5, 6, 7.

--- a/Doxygen/TwoD_Tutorial.md
+++ b/Doxygen/TwoD_Tutorial.md
@@ -15,6 +15,8 @@ this tutorial therefore reuse the same xms::XmUGrid API documented in the
 ## Example - Defining Ugrid Cells {#Example_DefiningA2dUGridCell}
 Supported 2D grid cells include: triangle (5), polygon (7), pixel (8), quad (9). A cell is defined with the number declaration of the shape (5, 7, 8, and 9 respectively as defined by the enumeration xms::XmUGridCellType), then the number of points, followed by the point indices. The cell definitions mirror VTK cell definitions which are available on page 9 of VTK File Formats for VTK version 4.2 at https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf.
 
+\note The integer cell-type values shown below are the on-the-wire cellstream format and are kept in sync with VTK and xms::XmUGridCellType. If that enum is ever renumbered or extended, update these examples to match.
+
 A triangle (5) has 3 points and the points are declared in a counter-clockwise direction. A cellstream example for a triangle is: 5, 3, 0, 1, 2.
 
 A polygon (7) does not a have a defined number of points, but the points are still declared in a counter-clockwise direction. A cellstream example for a polygon is: 7, 5, 0, 1, 2, 3, 4.

--- a/build.toml
+++ b/build.toml
@@ -4,9 +4,11 @@ ci_type = "github"
 extra_export_sources = ["test_files"]
 
 extra_cmake_text = """
-# Disable FP contraction (FMA fusion) for consistent floating-point results across
-# architectures. GCC on ARM emits fmadd at -O2+ which breaks exact arithmetic
-# predicates and produces non-deterministic geometry results.
+# Disable FP contraction (FMA fusion) for every non-MSVC compiler so floating-point
+# results are bit-identical across x86_64 and ARM. ARM GCC was the trigger (it emits
+# fmadd at -O2+, which broke exact arithmetic predicates and produced non-deterministic
+# geometry results), and we apply the same flag on x86_64 to keep cross-platform
+# behavior consistent. MSVC does not contract by default and is excluded.
 if (NOT MSVC)
     add_compile_options(-ffp-contract=off)
 endif()

--- a/xmsgrid/ugrid/XmUGrid.cpp
+++ b/xmsgrid/ugrid/XmUGrid.cpp
@@ -596,7 +596,8 @@ std::vector<T> iGetUniquePoints(const std::vector<T>& a_segments)
 //------------------------------------------------------------------------------
 /// \brief Build a polygon from vector of polygon segments.
 /// \param[in] a_segs Vector of segments that would make a polygon.
-/// \param[out] a_polygon Output polygon vector ordered either CW or CCW.
+/// \param[out] a_polygon Output polygon vector ordered either CW or CCW. On
+///             failure (return value false) a_polygon is cleared.
 /// \return true if every segment was placed; false if a_segs is empty or an
 ///         iteration could not extend the polygon (gap, dangling segment, etc.).
 //------------------------------------------------------------------------------
@@ -631,7 +632,10 @@ bool iBuildPolygon(std::vector<std::pair<T, T>>& a_segs, std::vector<T>& a_polyg
       }
     }
     if (a_polygon.size() == prevSize)
+    {
+      a_polygon.clear();
       return false;
+    }
   }
   return true;
 } // iBuildPolygon
@@ -6567,7 +6571,8 @@ void XmUGridUnitTests::testUgridWithInvalidCells()
 } // XmUGridUnitTests::testUgridWithInvalidCells
 //------------------------------------------------------------------------------
 /// \brief Test that iBuildPolygon rejects malformed segment lists rather than
-///        silently producing a partial polygon.
+///        silently producing a partial polygon, and that iMergeSegmentsToPoly
+///        clears its output on the same failure paths.
 //------------------------------------------------------------------------------
 void XmUGridUnitTests::testBuildPolygonFailurePaths()
 {
@@ -6579,21 +6584,37 @@ void XmUGridUnitTests::testBuildPolygonFailurePaths()
     TS_ASSERT(polygon.empty());
   }
 
-  // Dangling segment (open polyline plus a disconnected segment): no iteration
-  // can extend [1,2,3] to reach 4-5, so the function returns false.
+  // Dangling segment (open polyline plus a disconnected segment): the function
+  // returns false and clears any partial output it accumulated.
   {
     std::vector<std::pair<int, int>> segs = {{1, 2}, {2, 3}, {4, 5}};
     std::vector<int> polygon;
     TS_ASSERT(!iBuildPolygon(segs, polygon));
+    TS_ASSERT(polygon.empty());
   }
 
-  // Closed triangle: success path stays unchanged.
+  // Closed quad: exercises two real extension iterations (i=1 and i=2 both
+  // place a new segment) before the loop boundary closes the ring at i=3.
   {
-    std::vector<std::pair<int, int>> segs = {{1, 2}, {2, 3}, {1, 3}};
+    std::vector<std::pair<int, int>> segs = {{1, 2}, {2, 3}, {3, 4}, {1, 4}};
     std::vector<int> polygon;
     TS_ASSERT(iBuildPolygon(segs, polygon));
-    std::vector<int> expected = {1, 2, 3, 1};
+    std::vector<int> expected = {1, 2, 3, 4, 1};
     TS_ASSERT_EQUALS(expected, polygon);
+  }
+
+  // Route a malformed segment list through iMergeSegmentsToPoly: two
+  // disconnected segments cannot form a closed polygon, so the consolidated
+  // failure branch must clear a_polygon. Mute XM_ASSERT for the duration so
+  // debug builds do not abort on the deliberate failure.
+  {
+    VecPt3d segments = {{0, 0, 0}, {1, 0, 0}, {2, 0, 0}, {3, 0, 0}};
+    VecPt3d polygon;
+    bool wasAsserting = xmAsserting();
+    xmAsserting() = false;
+    iMergeSegmentsToPoly(segments, polygon);
+    xmAsserting() = wasAsserting;
+    TS_ASSERT(polygon.empty());
   }
 } // XmUGridUnitTests::testBuildPolygonFailurePaths
 

--- a/xmsgrid/ugrid/XmUGrid.cpp
+++ b/xmsgrid/ugrid/XmUGrid.cpp
@@ -597,16 +597,22 @@ std::vector<T> iGetUniquePoints(const std::vector<T>& a_segments)
 /// \brief Build a polygon from vector of polygon segments.
 /// \param[in] a_segs Vector of segments that would make a polygon.
 /// \param[out] a_polygon Output polygon vector ordered either CW or CCW.
+/// \return true if every segment was placed; false if a_segs is empty or an
+///         iteration could not extend the polygon (gap, dangling segment, etc.).
 //------------------------------------------------------------------------------
 template <typename T>
-void iBuildPolygon(std::vector<std::pair<T, T>>& a_segs, std::vector<T>& a_polygon)
+bool iBuildPolygon(std::vector<std::pair<T, T>>& a_segs, std::vector<T>& a_polygon)
 {
+  if (a_segs.empty())
+    return false;
+
   xms::VecChar placed(a_segs.size(), false);
   a_polygon.push_back(a_segs[0].first);
   a_polygon.push_back(a_segs[0].second);
   placed[0] = true;
   for (size_t i = 1; i != a_segs.size(); ++i)
   {
+    size_t prevSize = a_polygon.size();
     T toMatch = a_polygon.back();
     for (size_t j = 1; j != a_segs.size(); ++j)
     {
@@ -624,7 +630,10 @@ void iBuildPolygon(std::vector<std::pair<T, T>>& a_segs, std::vector<T>& a_polyg
         }
       }
     }
+    if (a_polygon.size() == prevSize)
+      return false;
   }
+  return true;
 } // iBuildPolygon
 //------------------------------------------------------------------------------
 /// \brief Builds a vector of sorted unique segments as a std::pair from a vector
@@ -689,20 +698,18 @@ void iMergeSegmentsToPoly(const VecPt3d& a_segments, VecPt3d& a_polygon)
   auto segIt = std::unique(segs.begin(), segs.end());
   segs.resize(segIt - segs.begin());
 
-  iBuildPolygon(segs, a_polygon);
-
-  if (a_polygon.size() > 3 && a_polygon.front() == a_polygon.back())
-  {
-    a_polygon.pop_back();
-    double area = gmPolygonArea(&a_polygon[0], (int)a_polygon.size());
-    if (area < 0)
-      std::reverse(a_polygon.begin(), a_polygon.end());
-  }
-  else
+  if (!iBuildPolygon(segs, a_polygon) ||
+      !(a_polygon.size() > 3 && a_polygon.front() == a_polygon.back()))
   {
     XM_ASSERT(0);
     a_polygon.clear();
+    return;
   }
+
+  a_polygon.pop_back();
+  double area = gmPolygonArea(&a_polygon[0], (int)a_polygon.size());
+  if (area < 0)
+    std::reverse(a_polygon.begin(), a_polygon.end());
 } // iMergeSegmentsToPoly
 //------------------------------------------------------------------------------
 /// \brief Get the dimension given the cell type (0d, 1d, 2d, or 3d).
@@ -6558,6 +6565,37 @@ void XmUGridUnitTests::testUgridWithInvalidCells()
   std::shared_ptr<XmUGrid> ugrid = XmUGrid::New(points, cellstream);
   TS_ASSERT_EQUALS(nullptr, ugrid);
 } // XmUGridUnitTests::testUgridWithInvalidCells
+//------------------------------------------------------------------------------
+/// \brief Test that iBuildPolygon rejects malformed segment lists rather than
+///        silently producing a partial polygon.
+//------------------------------------------------------------------------------
+void XmUGridUnitTests::testBuildPolygonFailurePaths()
+{
+  // Empty input: should not dereference past-the-end and should signal failure.
+  {
+    std::vector<std::pair<int, int>> segs;
+    std::vector<int> polygon;
+    TS_ASSERT(!iBuildPolygon(segs, polygon));
+    TS_ASSERT(polygon.empty());
+  }
+
+  // Dangling segment (open polyline plus a disconnected segment): no iteration
+  // can extend [1,2,3] to reach 4-5, so the function returns false.
+  {
+    std::vector<std::pair<int, int>> segs = {{1, 2}, {2, 3}, {4, 5}};
+    std::vector<int> polygon;
+    TS_ASSERT(!iBuildPolygon(segs, polygon));
+  }
+
+  // Closed triangle: success path stays unchanged.
+  {
+    std::vector<std::pair<int, int>> segs = {{1, 2}, {2, 3}, {1, 3}};
+    std::vector<int> polygon;
+    TS_ASSERT(iBuildPolygon(segs, polygon));
+    std::vector<int> expected = {1, 2, 3, 1};
+    TS_ASSERT_EQUALS(expected, polygon);
+  }
+} // XmUGridUnitTests::testBuildPolygonFailurePaths
 
 //------------------------------------------------------------------------------
 /// \brief Test that a cell stream is invalid for a UGrid with 99 points.

--- a/xmsgrid/ugrid/XmUGrid.t.h
+++ b/xmsgrid/ugrid/XmUGrid.t.h
@@ -70,6 +70,7 @@ public:
   void testCell3dFunctionCaching();
   void testLargeUGridLinkSpeed();
   void testUgridWithInvalidCells();
+  void testBuildPolygonFailurePaths();
 }; // XmUGridUnitTests
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
Resolves the six follow-up issues filed during review of #186:

- **#187** Bump `actions/checkout@v2` → `@v4` (4 jobs).
- **#188** Harden `iBuildPolygon`: empty-input guard, `bool` return on closure failure, propagated through `iMergeSegmentsToPoly`; new `testBuildPolygonFailurePaths` covers empty / dangling-segment / closed-triangle cases.
- **#189** Clarify `build.toml` comment — `-ffp-contract=off` applies to every non-MSVC compiler (ARM was the trigger; x86_64 keeps the same flag for cross-platform determinism).
- **#190** Drop bare `CLAUDE.md` from `.gitignore` so a shared project-level file can be committed; `.claude/` and `CLAUDE.local.md` remain ignored.
- **#191** Wrap all bare `if:` expressions in `${{ … }}` for consistency with the existing bracketed forms.
- **#192** Add a Doxygen `\note` in the 2D/3D tutorials stating the cell-type integers are kept in sync with VTK and `xms::XmUGridCellType`; integer literals retained because they are the on-the-wire cellstream format.

## Test plan
- [ ] CI runs `testBuildPolygonFailurePaths` and the rest of the suite green on Mac/Linux/Windows.
- [ ] Confirm Doxygen build still succeeds (no `\note` rendering issues).
- [ ] Visually verify CI workflow steps still trigger as expected on tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)