### PR TITLE
Bump xmscore to 7.0.12 and regenerate CI with xmsconan 2.18.0

### DIFF
--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -250,7 +250,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/build.toml
+++ b/build.toml
@@ -14,7 +14,7 @@ if (NOT MSVC)
 endif()
 """
 
-xms_dependencies = [{ name = "xmscore", version = "7.0.11" }]
+xms_dependencies = [{ name = "xmscore", version = "7.0.12" }]
 
 python_namespaced_dir = "grid"
 


### PR DESCRIPTION
Second library onto the VS2019 bridge, after xmscore ([xmscore#130](https://github.com/Aquaveo/xmscore/pull/130)). Five lines, two coupled changes.

## 1. xmscore `7.0.11` → `7.0.12` — required, not a routine bump

`xms_dependencies` pins an **exact** version, and **7.0.11 was never built for msvc 192**. Only `7.0.12` exists on `aquaveo-vs2019`. Left at 7.0.11, the VS2019 build of xmsgrid fails at graph resolution before compiling a single file.

This is inert for the VS2022 side: 7.0.12's only commit was a CI regeneration, so it is the same C++ source as 7.0.11, and it is published on both remotes at the same recipe revision `c58afa49b4625335e8fbaa650c925873`.

## 2. xmsconan `==2.16.0` → `>=2.18.0`

CI must generate the recipe with the same xmsconan the manual VS2019 track uses.

`XmsConan2File.export()` copies `xms_conan2_file.py` into the export folder, so its contents feed the **recipe revision hash**. xmsconan 2.18.0 changes that file by 192 lines — the msvc 192 fork (`_is_vs2019`, `vs2019_requirements`, `vs2019_dependency_overrides`). Generating with 2.16.0 in CI and 2.18.0 locally would publish **different rrevs for the same version**, leaving `aquaveo-stable` and `aquaveo-vs2019` silently out of step.

## Blast radius on the VS2022 side: none

- `build.toml` declares no `[vs2019_dependency_overrides]` table, so the generated `conanfile.py` gains no new attribute.
- On any toolchain that is not msvc 192 the dependency graph is unchanged — 2.18.0 refactored the inline `self.requires("boost/1.86.0")` / `self.requires("zlib/1.3.1")` calls into an iteration over `default_requirements` holding those same references in the same order.
- Verified the regenerated recipe: `xms_dependencies = ["xmscore/7.0.12"]`, `testing_framework = "cxxtest"` (relevant because `gtest/1.17.0` has no msvc 192 build).

## Last regeneration commit

2.17.0 floated generated CI from `==` onto `>=` with `--upgrade`, so future xmsconan releases arrive on the next CI run rather than needing a commit here. The flake job picks up `--upgrade`, which it lacked under the `==` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)