### PR TITLE
Add Python 3.14 to the CI matrix

### DIFF
--- a/.github/workflows/XmsGrid-CI.yaml
+++ b/.github/workflows/XmsGrid-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -63,11 +63,11 @@ jobs:
       fail-fast: false
       matrix:
         platform: [macos-15]
-        python-version: ['3.13']
+        python-version: ["3.13", "3.14"]
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-Clang${{ matrix.compiler-version }}-${{ matrix.build_type }}
+      MATRIX_NAME: ${{ matrix.platform }}-Clang${{ matrix.compiler-version }}-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmsgrid
       XMS_VERSION: '0.0.0'
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -164,7 +164,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi
@@ -205,19 +205,20 @@ jobs:
   # LINUX
   # ----------------------------------------------------------------------------------------------
   linux:
-    name: GCC-13 (${{ matrix.build_type }}, Linux)
+    name: GCC-13 (${{ matrix.build_type }}, ${{ matrix.python-version }}, Linux)
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/aquaveo/conan-gcc13-py3.13:latest
+      image: ghcr.io/aquaveo/conan-gcc13-py${{ matrix.python-version }}:latest
 
     strategy:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
+        python-version: ["3.13", "3.14"]
 
     env:
-      MATRIX_NAME: linux-GCC13-${{ matrix.build_type }}
+      MATRIX_NAME: linux-GCC13-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmsgrid
       XMS_VERSION: '0.0.0'
@@ -235,7 +236,7 @@ jobs:
       AQUAPI_PASSWORD: ${{ secrets.AQUAPI_PASSWORD_SECRET }}
       AQUAPI_URL: ${{ secrets.AQUAPI_URL_DEV }}
       # Python Variables
-      PYTHON_TARGET_VERSION: '3.13'
+      PYTHON_TARGET_VERSION: ${{ matrix.python-version }}
       RELEASE_PYTHON: 'False'
       CTEST_PARALLEL_LEVEL: '8'
 
@@ -250,7 +251,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -301,7 +302,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi
@@ -349,7 +350,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.13", "3.14"]
         compiler-version: [17]
         build_type: [Release, Debug]
 
@@ -398,7 +399,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.21.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/build.toml
+++ b/build.toml
@@ -14,7 +14,7 @@ if (NOT MSVC)
 endif()
 """
 
-xms_dependencies = [{ name = "xmscore", version = "7.0.12" }]
+xms_dependencies = [{ name = "xmscore", version = "7.0.13" }]
 
 python_namespaced_dir = "grid"
 
@@ -109,4 +109,6 @@ pybind_headers = [
 ]
 
 [ci]
-python_versions = ["3.10", "3.13"]
+python_versions = ["3.10", "3.13", "3.14"]
+mac_python_versions = ["3.13", "3.14"]
+linux_python_versions = ["3.13", "3.14"]


### PR DESCRIPTION
Second repo in the 3.14 rollout, following xmscore. Same shape as [xmscore#131](https://github.com/Aquaveo/xmscore/pull/131), which is merged and released as 7.0.13.

## The change

`build.toml` only — everything else in the diff is regenerated by `xmsconan_ci` at 2.21.0:

```toml
xms_dependencies = [{ name = "xmscore", version = "7.0.13" }]   # was 7.0.12

[ci]
python_versions       = ["3.10", "3.13", "3.14"]   # Windows
mac_python_versions   = ["3.13", "3.14"]
linux_python_versions = ["3.13", "3.14"]
```

## Why the xmscore bump is required, not incidental

Conan propagates `python_version` to `xms_dependencies`, and the generated CI runs `build.py` **without** `--build-missing`. So a 3.14 pybind leg here needs a *prebuilt* xmscore binary at that ABI or Conan fails resolution outright. 7.0.12 predates 3.14 support and has none.

xmscore 7.0.13 now carries them — verified on the remote rather than assumed:

```
$ conan list "xmscore/7.0.13:*" -r aquaveo
msvc 194        pybind=True  python_version=3.10 / 3.13 / 3.14
gcc 13          pybind=True  python_version=3.13 / 3.14
apple-clang 17  pybind=True  python_version=3.13 / 3.14
```

## Three lists, not one

Windows carries 3.10 for the desktop products' wheel and nothing else needs it. Every Linux entry needs a published `conan-gcc13-py<version>` container, and those exist for **3.13 and 3.14 only** — there is no py3.10/3.11/3.12 image on either registry. So Linux can't simply track `python_versions`.

## What to expect on merge

- **Release asset and wheel-artifact names change on macOS and Linux**, gaining `-py<version>`: `linux-GCC13-Release-py3.13.tar.gz` rather than `linux-GCC13-Release.tar.gz`. Those platforms produce two ABIs each now and the old names would have one leg overwrite the other. Windows already worked this way. Anything fetching these by exact name needs updating.
- The `linux` job's status-check name gains the ABI. `master` has **no `required_status_checks`** configured, so nothing is blocked by the rename — I checked before pushing.
- A tagged release will publish **7 wheels instead of 4**: 3.10/3.13/3.14 on Windows, 3.13/3.14 on macOS and Linux. Distinct `cp3XY` tags, so they coexist. Wheel upload stays gated on `refs/tags/` plus `build_type == 'Release'`, so this PR itself publishes nothing.

CI time and Conan storage roughly double, as they did for xmscore.

## No coverage pin needed

xmsgrid doesn't set `[ci].coverage`, so there's no `Coverage.yaml` whose Python version could drift. xmscore needed `[coverage].python_version = "3.13"` because coverage there follows the highest Linux entry and would otherwise have moved to 3.14 as a side effect.

## Risk

Low, relative to xmscore. That PR was the first compile of anything in the suite against the 3.14 C API, and it passed on MSVC, Clang and GCC — so the pybind layer is proven. xmsgrid has its own bindings, so this run is still the first look at *its* glue against 3.14, but the shared foundation is known good.

Post-merge plan, once green: tag **9.1.1** (patch — the change is CI plus a dependency bump, no library source change), then the manual VS2019 pass and its cp310 wheel to `aquaveo/stable`.
